### PR TITLE
feat: add app language selector

### DIFF
--- a/.github/cspell.json
+++ b/.github/cspell.json
@@ -16,10 +16,29 @@
   ],
   "useGitignore": true,
   "words": [
+    "assetlinks",
+    "bingogrid",
+    "christophermarx",
     "Contador",
+    "custombingo",
+    "firebaserc",
+    "fullfilled",
+    "fvmrc",
+    "groupchats",
+    "keypresses",
+    "libsqlite",
     "localizable",
+    "mdoe",
     "mostrado",
     "página",
-    "Texto"
+    "Podfile",
+    "podfix",
+    "Prefs",
+    "rerunnable",
+    "sideloading",
+    "SIGUSR",
+    "Taskfile",
+    "Texto",
+    "worktree"
   ]
 }

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,6 +20,7 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       flutter_channel: stable
+      flutter_version: 3.41.9
 
   spell-check:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/spell_check.yml@v1

--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -6,6 +6,7 @@ import 'package:custom_bingo/app/view/app_router.dart';
 import 'package:custom_bingo/app/view/custom_theme.dart';
 import 'package:custom_bingo/common/services/premium_service.dart';
 import 'package:custom_bingo/features/bingo_card/share_link.dart';
+import 'package:custom_bingo/features/settings/app_locale_settings.dart';
 import 'package:custom_bingo/features/settings/theme_settings.dart';
 import 'package:custom_bingo/l10n/arb/app_localizations.dart';
 import 'package:custom_bingo/util/logger.dart';
@@ -20,7 +21,7 @@ class App extends StatefulWidget {
   State<App> createState() => _AppState();
 }
 
-class _AppState extends State<App> {
+class _AppState extends State<App> with WidgetsBindingObserver {
   late final AppLinks _appLinks;
   late final GoRouter _router;
   StreamSubscription<Uri>? _linkSub;
@@ -29,6 +30,8 @@ class _AppState extends State<App> {
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    setPhoneLocale(WidgetsBinding.instance.platformDispatcher.locale);
     _router = createAppRouter();
     _appLinks = AppLinks();
     logI(
@@ -52,9 +55,15 @@ class _AppState extends State<App> {
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     _linkSub?.cancel();
     _router.dispose();
     super.dispose();
+  }
+
+  @override
+  void didChangeLocales(List<Locale>? locales) {
+    if (locales != null && locales.isNotEmpty) setPhoneLocale(locales.first);
   }
 
   void _handleIncomingLink(Uri uri, {required String source}) {
@@ -95,6 +104,8 @@ class _AppState extends State<App> {
   Widget build(BuildContext context) {
     final themeMode = appThemeModeBeacon.watch(context);
     final palette = appThemePaletteBeacon.watch(context);
+    final localeOverride = appLocaleOverrideBeacon.watch(context);
+    phoneLocaleBeacon.watch(context);
     final isPremiumUser = isPremiumUserBeacon.watch(context);
     final effectivePalette = availableAppThemePalette(
       palette,
@@ -105,6 +116,7 @@ class _AppState extends State<App> {
       theme: getThemeData(palette: effectivePalette),
       darkTheme: getThemeData(isDarkMode: true, palette: effectivePalette),
       themeMode: themeMode,
+      locale: localeOverride,
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       debugShowCheckedModeBanner: false,

--- a/lib/app/view/app_router.dart
+++ b/lib/app/view/app_router.dart
@@ -98,17 +98,18 @@ class _RouterErrorScreenState extends State<_RouterErrorScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = context.l10n;
     return Scaffold(
       body: SafeArea(
         child: Center(
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              const Text('Page Not Found'),
+              Text(l10n.pageNotFoundTitle),
               const SizedBox(height: 16),
               TextButton(
                 onPressed: () => context.go(AppRoutePaths.home),
-                child: const Text('Home'),
+                child: Text(l10n.homeButton),
               ),
             ],
           ),

--- a/lib/common/widgets/popup_menu.dart
+++ b/lib/common/widgets/popup_menu.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 
@@ -12,6 +14,9 @@ class PopupMenu extends StatefulWidget {
     this.offset = Offset.zero,
     this.childBuilder,
     this.useCard = true,
+    this.flipVerticallyToFit = false,
+    this.preferredMenuHeight = 320,
+    this.viewportMargin = 16,
   }) : assert(
          child != null || childBuilder != null,
          'child or childBuilder must be provided',
@@ -26,6 +31,9 @@ class PopupMenu extends StatefulWidget {
   final Alignment followerAnchor;
   final Offset offset;
   final bool useCard;
+  final bool flipVerticallyToFit;
+  final double preferredMenuHeight;
+  final double viewportMargin;
 
   @override
   State<PopupMenu> createState() => _PopupMenuState();
@@ -38,6 +46,8 @@ class _PopupMenuState extends State<PopupMenu> {
 
   void _showOverlay() {
     if (_isOpen) return;
+
+    final placement = _resolvePlacement();
 
     _overlayEntry = OverlayEntry(
       builder: (context) => Stack(
@@ -56,16 +66,21 @@ class _PopupMenuState extends State<PopupMenu> {
           // Popup menu
           CompositedTransformFollower(
             link: _layerLink,
-            offset: widget.offset,
-            targetAnchor: widget.targetAnchor,
-            followerAnchor: widget.followerAnchor,
+            offset: placement.offset,
+            targetAnchor: placement.targetAnchor,
+            followerAnchor: placement.followerAnchor,
             child:
                 Material(
                       type: MaterialType.transparency,
-                      child: _PopupMenuSurface(
-                        useCard: widget.useCard,
-                        padding: widget.padding,
-                        child: widget.popupMenuBuilder(context, _hideOverlay),
+                      child: ConstrainedBox(
+                        constraints: BoxConstraints(
+                          maxHeight: placement.maxHeight,
+                        ),
+                        child: _PopupMenuSurface(
+                          useCard: widget.useCard,
+                          padding: widget.padding,
+                          child: widget.popupMenuBuilder(context, _hideOverlay),
+                        ),
                       ),
                     )
                     .animate()
@@ -82,6 +97,59 @@ class _PopupMenuState extends State<PopupMenu> {
 
     Overlay.of(context).insert(_overlayEntry!);
     setState(() => _isOpen = true);
+  }
+
+  _PopupMenuPlacement _resolvePlacement() {
+    final fallback = _PopupMenuPlacement(
+      targetAnchor: widget.targetAnchor,
+      followerAnchor: widget.followerAnchor,
+      offset: widget.offset,
+      maxHeight: double.infinity,
+    );
+
+    if (!widget.flipVerticallyToFit) return fallback;
+
+    final targetRenderObject = context.findRenderObject();
+    final overlayRenderObject = Overlay.of(context).context.findRenderObject();
+    if (targetRenderObject is! RenderBox || overlayRenderObject is! RenderBox) {
+      return fallback;
+    }
+
+    final targetOffset = targetRenderObject.localToGlobal(
+      Offset.zero,
+      ancestor: overlayRenderObject,
+    );
+    final targetSize = targetRenderObject.size;
+    final overlaySize = overlayRenderObject.size;
+    final gap = widget.offset.dy.abs();
+    final spaceBelow =
+        overlaySize.height -
+        targetOffset.dy -
+        targetSize.height -
+        gap -
+        widget.viewportMargin;
+    final spaceAbove = targetOffset.dy - gap - widget.viewportMargin;
+    final opensDown = widget.targetAnchor.y > widget.followerAnchor.y;
+    final shouldFlipUp =
+        opensDown &&
+        spaceBelow < widget.preferredMenuHeight &&
+        spaceAbove > spaceBelow;
+
+    if (shouldFlipUp) {
+      return _PopupMenuPlacement(
+        targetAnchor: Alignment(widget.targetAnchor.x, -1),
+        followerAnchor: Alignment(widget.followerAnchor.x, 1),
+        offset: Offset(widget.offset.dx, -gap),
+        maxHeight: math.max(0, spaceAbove),
+      );
+    }
+
+    return _PopupMenuPlacement(
+      targetAnchor: widget.targetAnchor,
+      followerAnchor: widget.followerAnchor,
+      offset: widget.offset,
+      maxHeight: math.max(0, spaceBelow),
+    );
   }
 
   void _hideOverlay() {
@@ -116,6 +184,20 @@ class _PopupMenuState extends State<PopupMenu> {
           : GestureDetector(onTap: _showOverlay, child: widget.child),
     );
   }
+}
+
+class _PopupMenuPlacement {
+  const _PopupMenuPlacement({
+    required this.targetAnchor,
+    required this.followerAnchor,
+    required this.offset,
+    required this.maxHeight,
+  });
+
+  final Alignment targetAnchor;
+  final Alignment followerAnchor;
+  final Offset offset;
+  final double maxHeight;
 }
 
 class _PopupMenuSurface extends StatelessWidget {

--- a/lib/common/widgets/popup_menu.dart
+++ b/lib/common/widgets/popup_menu.dart
@@ -11,6 +11,7 @@ class PopupMenu extends StatefulWidget {
     this.followerAnchor = Alignment.topLeft,
     this.offset = Offset.zero,
     this.childBuilder,
+    this.useCard = true,
   }) : assert(
          child != null || childBuilder != null,
          'child or childBuilder must be provided',
@@ -24,6 +25,7 @@ class PopupMenu extends StatefulWidget {
   final Alignment targetAnchor;
   final Alignment followerAnchor;
   final Offset offset;
+  final bool useCard;
 
   @override
   State<PopupMenu> createState() => _PopupMenuState();
@@ -60,13 +62,10 @@ class _PopupMenuState extends State<PopupMenu> {
             child:
                 Material(
                       type: MaterialType.transparency,
-                      child: Card(
-                        elevation: 4,
-                        margin: EdgeInsets.zero,
-                        child: Padding(
-                          padding: widget.padding,
-                          child: widget.popupMenuBuilder(context, _hideOverlay),
-                        ),
+                      child: _PopupMenuSurface(
+                        useCard: widget.useCard,
+                        padding: widget.padding,
+                        child: widget.popupMenuBuilder(context, _hideOverlay),
                       ),
                     )
                     .animate()
@@ -116,5 +115,26 @@ class _PopupMenuState extends State<PopupMenu> {
           ? widget.childBuilder!(context, _showOverlay)
           : GestureDetector(onTap: _showOverlay, child: widget.child),
     );
+  }
+}
+
+class _PopupMenuSurface extends StatelessWidget {
+  const _PopupMenuSurface({
+    required this.useCard,
+    required this.padding,
+    required this.child,
+  });
+
+  final bool useCard;
+  final EdgeInsets padding;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final paddedChild = Padding(padding: padding, child: child);
+
+    if (!useCard) return paddedChild;
+
+    return Card(elevation: 4, margin: EdgeInsets.zero, child: paddedChild);
   }
 }

--- a/lib/features/bingo_card/bingo_card_logic.dart
+++ b/lib/features/bingo_card/bingo_card_logic.dart
@@ -14,37 +14,6 @@ final currentSelectedBingoCardName = Beacon.writable<String?>(
   getCurrentSelectedBingoCardName(),
 );
 
-// 	1.	📱 Phone comes out during vows
-// 2.	🥂 Champagne gets spilled
-// 3.	😢 Tears during a speech
-// 4.	🎩 Someone makes a dramatic entrance
-// 5.	💃 Kids take over the dance floor
-// 6.	🍻 Impromptu toast from a guest
-// 7.	👏 Crowd claps too early
-// 8.	🎶 DJ plays a throwback hit
-// 9.	📷 Someone takes a group photo and no one looks at the same camera
-final exampleGridItems = [
-  [
-    BingoItem(id: '1', text: '📱 Phone comes out during vows'),
-    BingoItem(id: '2', text: '🥂 Champagne gets spilled'),
-    BingoItem(id: '3', text: '😢 Tears during a speech'),
-  ],
-  [
-    BingoItem(id: '4', text: '🎩 Someone makes a dramatic entrance'),
-    BingoItem(id: '5', text: '💃 Kids take over the dance floor'),
-    BingoItem(id: '6', text: '🍻 Impromptu toast from a guest'),
-  ],
-  [
-    BingoItem(id: '7', text: '👏 Crowd claps too early'),
-    BingoItem(id: '8', text: '🎶 DJ plays a throwback hit'),
-    BingoItem(
-      id: '9',
-      text:
-          '📷 Someone takes a group photo and no one looks at the same camera',
-    ),
-  ],
-];
-
 class BingoCardController extends BeaconController {
   BingoCardController() {
     loadBoard();
@@ -67,7 +36,6 @@ class BingoCardController extends BeaconController {
     }
     final bingoCard = loadBingoCard(sharedPrefsBeacon.value, name);
     gridItems.value = bingoCard?.gridItems ?? [];
-    // gridItems.value = exampleGridItems;
     isEditing.value = bingoCard?.isEditing ?? true;
     lastChangeDateTime.value = bingoCard?.lastChangeDateTime ?? DateTime.now();
   }

--- a/lib/features/bingo_card/widgets/bingo_popup_menu.dart
+++ b/lib/features/bingo_card/widgets/bingo_popup_menu.dart
@@ -81,7 +81,7 @@ class BingoPopupMenu extends StatelessWidget {
                         children: [
                           Icon(PhosphorIcons.squaresFour()),
                           const SizedBox(width: 8),
-                          const Text('All boards'),
+                          Text(l10n.allBoardsMenuItem),
                         ],
                       ),
                     ),
@@ -168,7 +168,7 @@ class BingoPopupMenu extends StatelessWidget {
                           hideOverlay();
                           context.go(AppRoutePaths.root);
                         },
-                        child: const Text('Clear Settings'),
+                        child: Text(l10n.clearSettingsMenuItem),
                       ),
                   ],
                 ),

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -86,7 +86,7 @@ class HomeScreen extends StatelessWidget {
       context: context,
       builder: (context) => AlertDialog(
         title: Text(l10n.deleteCardTitle),
-        content: const Text('Do you want to delete this'),
+        content: Text(l10n.deleteCardConfirm),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context, false),
@@ -455,7 +455,7 @@ class _EmptyHomeGrid extends StatelessWidget {
         Icon(Icons.grid_view_rounded, size: 40, color: context.weakTextColor),
         const SizedBox(height: 12),
         Text(
-          'No boards yet',
+          context.l10n.noBoardsYet,
           textAlign: TextAlign.center,
           style: context.p1.copyWith(
             color: context.weakTextColor,

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -321,11 +321,11 @@ class _SupportCarouselItem extends StatelessWidget {
                         title,
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
-                      style: context.p1.copyWith(
-                        color: foregroundColor,
-                        fontWeight: FontWeight.bold,
+                        style: context.p1.copyWith(
+                          color: foregroundColor,
+                          fontWeight: FontWeight.bold,
+                        ),
                       ),
-                    ),
                       const SizedBox(height: 4),
                       Text(
                         subtitle,

--- a/lib/features/paywall/paywall_screen.dart
+++ b/lib/features/paywall/paywall_screen.dart
@@ -339,15 +339,12 @@ String _priceLabel(BuildContext context, bool isLoading, String? price) {
 
 String? _availabilityMessage(BuildContext context, RevenueCatState state) {
   return switch (state.status) {
-    RevenueCatStatus.error =>
-      state.message ?? context.l10n.paywallPurchasesUnavailable,
-    RevenueCatStatus.unavailable =>
-      state.message ?? context.l10n.paywallPlatformUnavailable,
+    RevenueCatStatus.error => context.l10n.paywallPurchasesUnavailable,
+    RevenueCatStatus.unavailable => context.l10n.paywallPlatformUnavailable,
     _ => null,
   };
 }
 
 String _messageFromRevenueCatError(BuildContext context, Object error) {
-  if (error is RevenueCatException) return error.message;
   return context.l10n.paywallCouldNotLoad;
 }

--- a/lib/features/settings/app_locale_settings.dart
+++ b/lib/features/settings/app_locale_settings.dart
@@ -1,0 +1,73 @@
+import 'dart:ui';
+
+import 'package:custom_bingo/common/services/shared_prefs.dart';
+import 'package:custom_bingo/l10n/arb/app_localizations.dart';
+import 'package:state_beacon/state_beacon.dart';
+
+const _appLocaleKey = 'app_locale';
+
+/// Null means "follow the device". Non-null values force the app locale.
+final appLocaleOverrideBeacon = Beacon.writable<Locale?>(getSavedAppLocale());
+
+/// Tracks the platform locale so widgets can describe the current system choice
+/// and rebuild when the phone language changes while the app is alive.
+final phoneLocaleBeacon = Beacon.writable<Locale>(
+  PlatformDispatcher.instance.locale,
+);
+
+Locale? getSavedAppLocale() {
+  final rawCode = sharedPrefsBeacon.value.getString(_appLocaleKey);
+  if (rawCode == null || rawCode.isEmpty) return null;
+  return supportedAppLanguageByCode(rawCode)?.locale;
+}
+
+Future<void> setAppLocaleOverride(Locale? locale) async {
+  if (locale == null) {
+    await sharedPrefsBeacon.value.remove(_appLocaleKey);
+  } else {
+    await sharedPrefsBeacon.value.setString(_appLocaleKey, locale.languageCode);
+  }
+  appLocaleOverrideBeacon.value = locale;
+}
+
+void setPhoneLocale(Locale locale) {
+  phoneLocaleBeacon.value = _supportedLocaleFor(locale) ?? locale;
+}
+
+Locale? _supportedLocaleFor(Locale locale) {
+  for (final supportedLocale in AppLocalizations.supportedLocales) {
+    if (supportedLocale.languageCode == locale.languageCode) {
+      return supportedLocale;
+    }
+  }
+  return null;
+}
+
+AppLanguage? supportedAppLanguageByCode(String languageCode) {
+  for (final language in supportedAppLanguages) {
+    if (language.locale.languageCode == languageCode) return language;
+  }
+  return null;
+}
+
+AppLanguage? appLanguageFor(Locale locale) {
+  return supportedAppLanguageByCode(locale.languageCode);
+}
+
+const supportedAppLanguages = <AppLanguage>[
+  AppLanguage(Locale('en'), 'English'),
+  AppLanguage(Locale('de'), 'Deutsch'),
+  AppLanguage(Locale('fr'), 'Français'),
+  AppLanguage(Locale('es'), 'Español'),
+  AppLanguage(Locale('pt'), 'Português'),
+  AppLanguage(Locale('zh'), '中文'),
+  AppLanguage(Locale('ja'), '日本語'),
+  AppLanguage(Locale('ar'), 'العربية'),
+];
+
+class AppLanguage {
+  const AppLanguage(this.locale, this.nativeName);
+
+  final Locale locale;
+  final String nativeName;
+}

--- a/lib/features/settings/settings.dart
+++ b/lib/features/settings/settings.dart
@@ -7,6 +7,7 @@ import 'package:custom_bingo/common/services/revenue_cat_service.dart';
 import 'package:custom_bingo/common/services/user_id.dart';
 import 'package:custom_bingo/common/services/userorient_service.dart';
 import 'package:custom_bingo/common/widgets/premium_gate.dart';
+import 'package:custom_bingo/common/widgets/popup_menu.dart';
 import 'package:custom_bingo/features/settings/app_locale_settings.dart';
 import 'package:custom_bingo/features/settings/settings_preferences.dart';
 import 'package:custom_bingo/features/settings/theme_settings.dart';
@@ -167,20 +168,22 @@ class _RevenueCatUserIdFooter extends StatelessWidget {
         children: [
           Expanded(
             child: SelectableText(
-              'RevenueCat user id: $userId',
+              context.l10n.revenueCatUserIdLabel(userId),
               style: context.caption.copyWith(color: context.weakTextColor),
             ),
           ),
           IconButton(
             visualDensity: VisualDensity.compact,
-            tooltip: 'Copy RevenueCat user id',
+            tooltip: context.l10n.copyRevenueCatUserIdTooltip,
             iconSize: 16,
             color: context.weakTextColor,
             onPressed: () async {
               await Clipboard.setData(ClipboardData(text: userId));
               if (!context.mounted) return;
               ScaffoldMessenger.of(context).showSnackBar(
-                const SnackBar(content: Text('RevenueCat user id copied.')),
+                SnackBar(
+                  content: Text(context.l10n.revenueCatUserIdCopiedToast),
+                ),
               );
             },
             icon: Icon(PhosphorIcons.copy()),
@@ -330,7 +333,11 @@ class _LanguageSettingsTile extends StatelessWidget {
     final phoneLanguage =
         appLanguageFor(phoneLocale)?.nativeName ??
         phoneLocale.languageCode.toUpperCase();
-    final dropdownValue = selectedLocale?.languageCode;
+    final overrideLocale = selectedLocale;
+    final selectedLabel = overrideLocale == null
+        ? l10n.languageSettingsSystemOption(phoneLanguage)
+        : appLanguageFor(overrideLocale)?.nativeName ??
+              overrideLocale.languageCode.toUpperCase();
 
     return _SettingsTile(
       title: l10n.languageSettingsTitle,
@@ -338,27 +345,194 @@ class _LanguageSettingsTile extends StatelessWidget {
           ? l10n.languageSettingsSystemDescription(phoneLanguage)
           : l10n.languageSettingsOverrideDescription,
       icon: PhosphorIcons.translate(),
-      child: DropdownButtonFormField<String?>(
-        initialValue: dropdownValue,
-        isExpanded: true,
-        decoration: InputDecoration(
-          labelText: l10n.languageSettingsSelectorLabel,
-        ),
-        items: [
-          DropdownMenuItem<String?>(
-            child: Text(l10n.languageSettingsSystemOption(phoneLanguage)),
+      child: _LanguageSelector(
+        label: l10n.languageSettingsSelectorLabel,
+        selectedLabel: selectedLabel,
+        selectedLocale: selectedLocale,
+        systemLabel: l10n.languageSettingsSystemOption(phoneLanguage),
+        onLocaleSelected: onLocaleSelected,
+      ),
+    );
+  }
+}
+
+class _LanguageSelector extends StatelessWidget {
+  const _LanguageSelector({
+    required this.label,
+    required this.selectedLabel,
+    required this.selectedLocale,
+    required this.systemLabel,
+    required this.onLocaleSelected,
+  });
+
+  final String label;
+  final String selectedLabel;
+  final Locale? selectedLocale;
+  final String systemLabel;
+  final ValueChanged<Locale?> onLocaleSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final width = constraints.maxWidth.isFinite
+            ? constraints.maxWidth
+            : MediaQuery.sizeOf(context).width - 48;
+
+        return PopupMenu(
+          padding: EdgeInsets.zero,
+          useCard: false,
+          targetAnchor: Alignment.bottomLeft,
+          followerAnchor: Alignment.topLeft,
+          offset: const Offset(0, 8),
+          childBuilder: (context, showOverlay) {
+            return InkWell(
+              borderRadius: kBorderradiusSmall,
+              onTap: showOverlay,
+              child: InputDecorator(
+                decoration: InputDecoration(
+                  labelText: label,
+                  suffixIcon: Icon(
+                    PhosphorIcons.caretDown(),
+                    color: context.weakTextColor,
+                    size: 18,
+                  ),
+                ),
+                child: Text(
+                  selectedLabel,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: context.p1,
+                ),
+              ),
+            );
+          },
+          popupMenuBuilder: (menuContext, hideOverlay) {
+            return _LanguageSelectorMenu(
+              width: width,
+              selectedLocale: selectedLocale,
+              systemLabel: systemLabel,
+              onSelect: (locale) {
+                hideOverlay();
+                onLocaleSelected(locale);
+              },
+            );
+          },
+        );
+      },
+    );
+  }
+}
+
+class _LanguageSelectorMenu extends StatelessWidget {
+  const _LanguageSelectorMenu({
+    required this.width,
+    required this.selectedLocale,
+    required this.systemLabel,
+    required this.onSelect,
+  });
+
+  final double width;
+  final Locale? selectedLocale;
+  final String systemLabel;
+  final ValueChanged<Locale?> onSelect;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: width,
+      constraints: const BoxConstraints(maxHeight: 420),
+      decoration: BoxDecoration(
+        color: context.cardColor,
+        borderRadius: kBorderradiusSmall,
+        border: Border.all(color: context.outlineColor),
+        boxShadow: [
+          BoxShadow(
+            color: context.shadowColor.withValues(alpha: 0.16),
+            blurRadius: 22,
+            offset: const Offset(0, 12),
           ),
-          for (final language in supportedAppLanguages)
-            DropdownMenuItem<String?>(
-              value: language.locale.languageCode,
-              child: Text(language.nativeName),
-            ),
         ],
-        onChanged: (languageCode) {
-          onLocaleSelected(
-            supportedAppLanguageByCode(languageCode ?? '')?.locale,
-          );
-        },
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.symmetric(vertical: 6),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            _LanguageSelectorMenuItem(
+              label: systemLabel,
+              isSelected: selectedLocale == null,
+              onTap: () => onSelect(null),
+            ),
+            Divider(height: 1, color: context.outlineColor),
+            for (final language in supportedAppLanguages)
+              _LanguageSelectorMenuItem(
+                label: language.nativeName,
+                isSelected:
+                    selectedLocale?.languageCode ==
+                    language.locale.languageCode,
+                onTap: () => onSelect(language.locale),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _LanguageSelectorMenuItem extends StatelessWidget {
+  const _LanguageSelectorMenuItem({
+    required this.label,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  final String label;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: isSelected
+          ? context.primary.withValues(alpha: 0.12)
+          : Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        child: SizedBox(
+          height: 54,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 14),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    label,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: context.p1.copyWith(
+                      color: context.textColor,
+                      fontWeight: isSelected
+                          ? FontWeight.w700
+                          : FontWeight.w500,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 10),
+                AnimatedOpacity(
+                  opacity: isSelected ? 1 : 0,
+                  duration: const Duration(milliseconds: 120),
+                  child: Icon(
+                    PhosphorIcons.check(),
+                    color: context.primary,
+                    size: 20,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
       ),
     );
   }

--- a/lib/features/settings/settings.dart
+++ b/lib/features/settings/settings.dart
@@ -7,6 +7,7 @@ import 'package:custom_bingo/common/services/revenue_cat_service.dart';
 import 'package:custom_bingo/common/services/user_id.dart';
 import 'package:custom_bingo/common/services/userorient_service.dart';
 import 'package:custom_bingo/common/widgets/premium_gate.dart';
+import 'package:custom_bingo/features/settings/app_locale_settings.dart';
 import 'package:custom_bingo/features/settings/settings_preferences.dart';
 import 'package:custom_bingo/features/settings/theme_settings.dart';
 import 'package:custom_bingo/l10n/l10n.dart';
@@ -40,6 +41,8 @@ class SettingsScreen extends StatelessWidget {
     final themePalette = appThemePaletteBeacon.watch(context);
     final isPremiumUser = isPremiumUserBeacon.watch(context);
     final enableConfetti = enableConfettiBeacon.watch(context);
+    final selectedLocale = appLocaleOverrideBeacon.watch(context);
+    final phoneLocale = phoneLocaleBeacon.watch(context);
     final effectiveThemePalette = availableAppThemePalette(
       themePalette,
       isPremiumUser: isPremiumUser,
@@ -85,6 +88,11 @@ class SettingsScreen extends StatelessWidget {
               _ThemePaletteSettingsTile(
                 selectedPalette: effectiveThemePalette,
                 onPaletteSelected: setAppThemePalette,
+              ),
+              _LanguageSettingsTile(
+                selectedLocale: selectedLocale,
+                phoneLocale: phoneLocale,
+                onLocaleSelected: setAppLocaleOverride,
               ),
               _SettingsTile(
                 title: l10n.enableConfettiLabel,
@@ -301,6 +309,57 @@ class _SettingsIcon extends StatelessWidget {
         borderRadius: kBorderradiusSmall,
       ),
       child: Icon(icon, color: context.primary, size: 22),
+    );
+  }
+}
+
+class _LanguageSettingsTile extends StatelessWidget {
+  const _LanguageSettingsTile({
+    required this.selectedLocale,
+    required this.phoneLocale,
+    required this.onLocaleSelected,
+  });
+
+  final Locale? selectedLocale;
+  final Locale phoneLocale;
+  final ValueChanged<Locale?> onLocaleSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final phoneLanguage =
+        appLanguageFor(phoneLocale)?.nativeName ??
+        phoneLocale.languageCode.toUpperCase();
+    final dropdownValue = selectedLocale?.languageCode;
+
+    return _SettingsTile(
+      title: l10n.languageSettingsTitle,
+      subtitle: selectedLocale == null
+          ? l10n.languageSettingsSystemDescription(phoneLanguage)
+          : l10n.languageSettingsOverrideDescription,
+      icon: PhosphorIcons.translate(),
+      child: DropdownButtonFormField<String?>(
+        initialValue: dropdownValue,
+        isExpanded: true,
+        decoration: InputDecoration(
+          labelText: l10n.languageSettingsSelectorLabel,
+        ),
+        items: [
+          DropdownMenuItem<String?>(
+            child: Text(l10n.languageSettingsSystemOption(phoneLanguage)),
+          ),
+          for (final language in supportedAppLanguages)
+            DropdownMenuItem<String?>(
+              value: language.locale.languageCode,
+              child: Text(language.nativeName),
+            ),
+        ],
+        onChanged: (languageCode) {
+          onLocaleSelected(
+            supportedAppLanguageByCode(languageCode ?? '')?.locale,
+          );
+        },
+      ),
     );
   }
 }

--- a/lib/features/settings/settings.dart
+++ b/lib/features/settings/settings.dart
@@ -382,6 +382,8 @@ class _LanguageSelector extends StatelessWidget {
         return PopupMenu(
           padding: EdgeInsets.zero,
           useCard: false,
+          flipVerticallyToFit: true,
+          preferredMenuHeight: 420,
           targetAnchor: Alignment.bottomLeft,
           followerAnchor: Alignment.topLeft,
           offset: const Offset(0, 8),

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -24,23 +24,23 @@
     "@updateCardButton": {
         "description": "Confirm button on the edit-card screen"
     },
-    "newBoardPreMadeSectionTitle": "Your pre-made items",
+    "newBoardPreMadeSectionTitle": "عناصرك الجاهزة",
     "@newBoardPreMadeSectionTitle": {
         "description": "Expandable section title for pre-made items on the new-board screen"
     },
-    "newBoardPreMadeButton": "Start with pre-made items",
+    "newBoardPreMadeButton": "ابدأ بعناصر جاهزة",
     "@newBoardPreMadeButton": {
         "description": "Button that opens pre-made item selection from the new-board screen"
     },
-    "newBoardPreMadeChangeButton": "Change pre-made items",
+    "newBoardPreMadeChangeButton": "تغيير العناصر الجاهزة",
     "@newBoardPreMadeChangeButton": {
         "description": "Button that reopens pre-made item selection after items have been applied"
     },
-    "newBoardPreMadeClearButton": "Clear pre-made items",
+    "newBoardPreMadeClearButton": "مسح العناصر الجاهزة",
     "@newBoardPreMadeClearButton": {
         "description": "Button that clears applied pre-made entries from the new-board form"
     },
-    "newBoardPreMadeAppliedCount": "{count} pre-made entries applied",
+    "newBoardPreMadeAppliedCount": "تم تطبيق {count} إدخالات جاهزة",
     "@newBoardPreMadeAppliedCount": {
         "description": "Summary of how many pre-made entries are applied to the new-board form",
         "placeholders": {
@@ -50,7 +50,7 @@
             }
         }
     },
-    "newBoardPreMadeFullSummary": "{used} will be drawn at random for this board.",
+    "newBoardPreMadeFullSummary": "سيتم اختيار {used} عشوائيًا لهذا اللوح.",
     "@newBoardPreMadeFullSummary": {
         "description": "Summary when applied pre-made entries can fill the new board",
         "placeholders": {
@@ -60,7 +60,7 @@
             }
         }
     },
-    "newBoardPreMadePartialSummary": "{used} cells will be filled. {blank} will stay blank.",
+    "newBoardPreMadePartialSummary": "سيتم ملء {used} خانات. ستبقى {blank} فارغة.",
     "@newBoardPreMadePartialSummary": {
         "description": "Summary when applied pre-made entries are fewer than the board cells",
         "placeholders": {
@@ -82,19 +82,19 @@
     "@toggleHint": {
         "description": "Hint banner above the bingo grid"
     },
-    "editingHintBefore": "Press the lock icon",
+    "editingHintBefore": "اضغط على أيقونة القفل",
     "@editingHintBefore": {
         "description": "First half of the hint that explains the lock toggle. The lock icon is rendered between the two halves."
     },
-    "editingHintAfter": " to make the fields not editable anymore.",
+    "editingHintAfter": " لجعل الخانات غير قابلة للتحرير.",
     "@editingHintAfter": {
         "description": "Second half of the lock-toggle hint, rendered after the lock icon."
     },
-    "deleteCardTitle": "Delete Card",
+    "deleteCardTitle": "حذف البطاقة",
     "@deleteCardTitle": {
         "description": "Title of the delete-card confirmation dialog"
     },
-    "deleteCardConfirm": "Are you sure you want to delete this card?",
+    "deleteCardConfirm": "هل أنت متأكد أنك تريد حذف هذه البطاقة؟",
     "@deleteCardConfirm": {
         "description": "Body of the delete-card confirmation dialog"
     },
@@ -106,11 +106,11 @@
     "@delete": {
         "description": "Generic delete button"
     },
-    "shuffleCardTitle": "Shuffle Card",
+    "shuffleCardTitle": "خلط البطاقة",
     "@shuffleCardTitle": {
         "description": "Title of the shuffle confirmation dialog"
     },
-    "shuffleCardConfirm": "Are you sure you want to shuffle this card? All fields will be unchecked, after shuffling.",
+    "shuffleCardConfirm": "هل أنت متأكد أنك تريد خلط هذه البطاقة؟ سيتم إلغاء تحديد كل الخانات بعد الخلط.",
     "@shuffleCardConfirm": {
         "description": "Body of the shuffle confirmation dialog"
     },
@@ -118,19 +118,19 @@
     "@shuffle": {
         "description": "Confirm button to shuffle the card"
     },
-    "ratingPromptTitle": "Do you like Custom Bingo?",
+    "ratingPromptTitle": "هل يعجبك Custom Bingo؟",
     "@ratingPromptTitle": {
         "description": "Title of the dialog shown before asking for an app store review"
     },
-    "ratingPromptBody": "If so, a quick store review helps others find it.",
+    "ratingPromptBody": "إذا كان كذلك، فإن تقييمًا سريعًا في المتجر يساعد الآخرين على العثور عليه.",
     "@ratingPromptBody": {
         "description": "Body of the dialog shown before asking for an app store review"
     },
-    "ratingPromptNo": "Not really",
+    "ratingPromptNo": "ليس كثيرًا",
     "@ratingPromptNo": {
         "description": "Dismiss button for the rating prompt dialog"
     },
-    "ratingPromptYes": "Yes, I like it",
+    "ratingPromptYes": "نعم، يعجبني",
     "@ratingPromptYes": {
         "description": "Confirm button that continues to the native app store review flow"
     },
@@ -142,7 +142,7 @@
     "@boardActionEditBoard": {
         "description": "Menu item that opens the board edit flow from the board action bar"
     },
-    "boardActionAddPreMadeItems": "Add pre-made items",
+    "boardActionAddPreMadeItems": "إضافة عناصر جاهزة",
     "@boardActionAddPreMadeItems": {
         "description": "Debug menu item placeholder for filling a board with pre-made items"
     },
@@ -154,11 +154,11 @@
     "@edit": {
         "description": "Edit menu item in a cell's context menu"
     },
-    "markDone": "Mark Done",
+    "markDone": "وضع علامة تم",
     "@markDone": {
         "description": "Cell context menu item: mark this cell as done"
     },
-    "markNotDone": "Mark Not Done",
+    "markNotDone": "إزالة علامة تم",
     "@markNotDone": {
         "description": "Cell context menu item: clear the done state"
     },
@@ -166,15 +166,53 @@
     "@newCardMenuItem": {
         "description": "Menu item that opens the new-card screen"
     },
+    "allBoardsMenuItem": "كل الألواح",
+    "@allBoardsMenuItem": {
+        "description": "Menu item that opens the list of all saved boards"
+    },
     "yourCardsHeader": "لوحاتك",
     "@yourCardsHeader": {
         "description": "Section header in the popup menu listing saved cards"
+    },
+    "noBoardsYet": "لا توجد ألواح بعد",
+    "@noBoardsYet": {
+        "description": "Empty-state title shown when there are no saved boards"
+    },
+    "pageNotFoundTitle": "الصفحة غير موجودة",
+    "@pageNotFoundTitle": {
+        "description": "Title shown on the fallback route when a page cannot be found"
+    },
+    "homeButton": "الرئيسية",
+    "@homeButton": {
+        "description": "Button that navigates back to the home screen"
+    },
+    "revenueCatUserIdLabel": "معرّف مستخدم RevenueCat: {userId}",
+    "@revenueCatUserIdLabel": {
+        "description": "Debug settings label showing the RevenueCat user id",
+        "placeholders": {
+            "userId": {
+                "type": "String",
+                "example": "abc123"
+            }
+        }
+    },
+    "copyRevenueCatUserIdTooltip": "نسخ معرّف مستخدم RevenueCat",
+    "@copyRevenueCatUserIdTooltip": {
+        "description": "Tooltip for copying the RevenueCat user id from debug settings"
+    },
+    "revenueCatUserIdCopiedToast": "تم نسخ معرّف مستخدم RevenueCat.",
+    "@revenueCatUserIdCopiedToast": {
+        "description": "Toast shown after copying the RevenueCat user id"
     },
     "settingsHeader": "الإعدادات",
     "@settingsHeader": {
         "description": "Section header in the popup menu"
     },
-    "appearanceMenuItem": "Appearance",
+    "clearSettingsMenuItem": "مسح الإعدادات",
+    "@clearSettingsMenuItem": {
+        "description": "Debug menu item that clears saved settings"
+    },
+    "appearanceMenuItem": "المظهر",
     "@appearanceMenuItem": {
         "description": "Menu item that opens the appearance settings screen"
     },
@@ -254,63 +292,63 @@
     "@enableConfettiSettingsDescription": {
         "description": "Settings helper text for the confetti preference switch"
     },
-    "preMadeTilesTitle": "Pre-made tiles",
+    "preMadeTilesTitle": "خانات جاهزة",
     "@preMadeTilesTitle": {
         "description": "Title of the pre-made tiles settings screen and menu entry"
     },
-    "preMadeTilesSettingsDescription": "Create reusable tile text for future boards.",
+    "preMadeTilesSettingsDescription": "أنشئ نصوص خانات قابلة لإعادة الاستخدام للألواح القادمة.",
     "@preMadeTilesSettingsDescription": {
         "description": "Settings entry helper text for pre-made tiles"
     },
-    "preMadeTilesDescription": "Create reusable bingo entries here. When you create a new board, you can add them without typing everything again.",
+    "preMadeTilesDescription": "أنشئ هنا إدخالات بينغو قابلة لإعادة الاستخدام. عند إنشاء لوح جديد، يمكنك إضافتها دون كتابة كل شيء مرة أخرى.",
     "@preMadeTilesDescription": {
         "description": "Description shown below the pre-made tiles screen title"
     },
-    "preMadeTilesSelectMode": "Select",
+    "preMadeTilesSelectMode": "تحديد",
     "@preMadeTilesSelectMode": {
         "description": "Segmented control label for selecting pre-made tiles"
     },
-    "preMadeTilesEditMode": "Edit",
+    "preMadeTilesEditMode": "تحرير",
     "@preMadeTilesEditMode": {
         "description": "Segmented control label for editing pre-made tiles"
     },
-    "preMadeTileHint": "Tile text",
+    "preMadeTileHint": "نص الخانة",
     "@preMadeTileHint": {
         "description": "Placeholder for a pre-made tile text field"
     },
-    "preMadeTilesAdd": "Add tile",
+    "preMadeTilesAdd": "إضافة خانة",
     "@preMadeTilesAdd": {
         "description": "Accessible label and tooltip for adding a pre-made tile"
     },
-    "preMadeTilesDelete": "Delete tile",
+    "preMadeTilesDelete": "حذف خانة",
     "@preMadeTilesDelete": {
         "description": "Accessible label and tooltip for deleting a pre-made tile"
     },
-    "preMadeTilesSelectAll": "Un/select all",
+    "preMadeTilesSelectAll": "تحديد/إلغاء تحديد الكل",
     "@preMadeTilesSelectAll": {
         "description": "Checkbox label for toggling all pre-made tile selections"
     },
-    "preMadeTilesSelectNone": "Select none",
+    "preMadeTilesSelectNone": "إلغاء التحديد",
     "@preMadeTilesSelectNone": {
         "description": "Button label for clearing all selected pre-made tiles"
     },
-    "preMadeTilesApply": "Apply",
+    "preMadeTilesApply": "تطبيق",
     "@preMadeTilesApply": {
         "description": "Button label for applying selected pre-made tiles to a board"
     },
-    "preMadeTilesReplaceItems": "Replace items",
+    "preMadeTilesReplaceItems": "استبدال العناصر",
     "@preMadeTilesReplaceItems": {
         "description": "Button label for replacing current board items with selected pre-made items"
     },
-    "preMadeTilesFillItems": "Fill items",
+    "preMadeTilesFillItems": "ملء العناصر",
     "@preMadeTilesFillItems": {
         "description": "Button label for filling empty board items with selected pre-made items"
     },
-    "preMadeTilesBoardActionHelp": "Replace swaps the board entries with a random draw from your selection. Fill only adds items to empty tiles. On odd boards, the center tile stays in place.",
+    "preMadeTilesBoardActionHelp": "الاستبدال يبدل إدخالات اللوح بسحب عشوائي من اختيارك. الملء يضيف العناصر إلى الخانات الفارغة فقط. في الألواح الفردية، تبقى الخانة الوسطى كما هي.",
     "@preMadeTilesBoardActionHelp": {
         "description": "Helper text explaining replace and fill actions for pre-made items on an existing board"
     },
-    "preMadeTilesSelectedCount": "{selected} / {total} selected",
+    "preMadeTilesSelectedCount": "{selected} / {total} محددة",
     "@preMadeTilesSelectedCount": {
         "description": "Count of selected pre-made tiles",
         "placeholders": {
@@ -324,135 +362,135 @@
             }
         }
     },
-    "preMadeTilesEmptyTitle": "No tiles yet",
+    "preMadeTilesEmptyTitle": "لا توجد خانات بعد",
     "@preMadeTilesEmptyTitle": {
         "description": "Empty-state title for the pre-made tiles screen"
     },
-    "preMadeTilesEmptyBody": "Add a tile to start building a reusable list.",
+    "preMadeTilesEmptyBody": "أضف خانة لبدء إنشاء قائمة قابلة لإعادة الاستخدام.",
     "@preMadeTilesEmptyBody": {
         "description": "Empty-state helper text for the pre-made tiles screen"
     },
-    "proposeFeatures": "Propose Features",
+    "proposeFeatures": "اقتراح ميزات",
     "@proposeFeatures": {
         "description": "Menu item that opens the UserOrient feedback board"
     },
-    "proposeFeaturesSettingsDescription": "Vote on ideas and suggest what to build next.",
+    "proposeFeaturesSettingsDescription": "صوّت على الأفكار واقترح ما يجب بناؤه لاحقًا.",
     "@proposeFeaturesSettingsDescription": {
         "description": "Settings helper text for the feature request entry"
     },
-    "supportMeDirectly": "Support the developer",
+    "supportMeDirectly": "دعم المطور",
     "@supportMeDirectly": {
         "description": "Menu item that opens the direct-support paywall"
     },
-    "supportMeDirectlySettingsDescription": "Help fund development and keep the app improving.",
+    "supportMeDirectlySettingsDescription": "ساعد في تمويل التطوير والحفاظ على تحسين التطبيق.",
     "@supportMeDirectlySettingsDescription": {
         "description": "Settings helper text for the direct support entry"
     },
-    "supportCarouselProTitle": "Support Custom Bingo",
+    "supportCarouselProTitle": "ادعم Custom Bingo",
     "@supportCarouselProTitle": {
         "description": "Title of the home-screen support carousel item that opens the paywall"
     },
-    "supportCarouselProSubtitle": "Unlock bonus colors and help keep the app independent.",
+    "supportCarouselProSubtitle": "افتح ألوانًا إضافية وساعد في بقاء التطبيق مستقلًا.",
     "@supportCarouselProSubtitle": {
         "description": "Subtitle of the home-screen support carousel item that opens the paywall"
     },
-    "supportCarouselRateTitle": "Enjoying the app?",
+    "supportCarouselRateTitle": "هل تستمتع بالتطبيق؟",
     "@supportCarouselRateTitle": {
         "description": "Title of the home-screen support carousel item that asks for a store review"
     },
-    "supportCarouselRateSubtitle": "A quick review helps more people find Custom Bingo.",
+    "supportCarouselRateSubtitle": "تقييم سريع يساعد المزيد من الناس على العثور على Custom Bingo.",
     "@supportCarouselRateSubtitle": {
         "description": "Subtitle of the home-screen support carousel item that asks for a store review"
     },
-    "rateTheApp": "Rate the app",
+    "rateTheApp": "تقييم التطبيق",
     "@rateTheApp": {
         "description": "Settings entry that opens the native store rating dialog"
     },
-    "rateTheAppSettingsDescription": "Open the store rating prompt.",
+    "rateTheAppSettingsDescription": "فتح طلب التقييم في المتجر.",
     "@rateTheAppSettingsDescription": {
         "description": "Settings helper text for the app rating entry"
     },
-    "contactMe": "Contact me",
+    "contactMe": "تواصل معي",
     "@contactMe": {
         "description": "Settings entry that opens an email composer"
     },
-    "contactMeSettingsDescription": "Send feedback, questions, or bug reports by email.",
+    "contactMeSettingsDescription": "أرسل ملاحظات أو أسئلة أو تقارير أخطاء عبر البريد الإلكتروني.",
     "@contactMeSettingsDescription": {
         "description": "Settings helper text for the contact email entry"
     },
-    "paywallTitle": "Support Custom Bingo",
+    "paywallTitle": "ادعم Custom Bingo",
     "@paywallTitle": {
         "description": "AppBar title of the direct-support paywall"
     },
-    "paywallThankYouTitle": "Thank you",
+    "paywallThankYouTitle": "شكرًا لك",
     "@paywallThankYouTitle": {
         "description": "Paywall title shown after Pro access is active"
     },
-    "paywallSupportTitle": "Support Custom Bingo",
+    "paywallSupportTitle": "ادعم Custom Bingo",
     "@paywallSupportTitle": {
         "description": "Main title on the direct-support paywall"
     },
-    "paywallSupportBody": "This purchase supports me, the developer, directly. You get my gratitude and a few small bonus things for your boards.",
+    "paywallSupportBody": "هذا الشراء يدعمني مباشرة بصفتي المطور. تحصل على امتناني وبعض الإضافات الصغيرة لألواحك.",
     "@paywallSupportBody": {
         "description": "Main body copy on the direct-support paywall"
     },
-    "paywallBonusGratitude": "My gratitude, sincerely.",
+    "paywallBonusGratitude": "امتناني الصادق.",
     "@paywallBonusGratitude": {
         "description": "First benefit line on the direct-support paywall"
     },
-    "paywallBonusColors": "A few extra board colors.",
+    "paywallBonusColors": "بعض ألوان الألواح الإضافية.",
     "@paywallBonusColors": {
         "description": "Second benefit line on the direct-support paywall"
     },
-    "paywallBonusExtras": "Small supporter extras over time.",
+    "paywallBonusExtras": "إضافات صغيرة للداعمين مع الوقت.",
     "@paywallBonusExtras": {
         "description": "Third benefit line on the direct-support paywall"
     },
-    "paywallFreeForever": "No one ever needs to pay for this app. Custom Bingo stays usable for everyone.",
+    "paywallFreeForever": "لا يحتاج أحد أبدًا إلى الدفع لاستخدام هذا التطبيق. سيبقى Custom Bingo متاحًا للجميع.",
     "@paywallFreeForever": {
         "description": "Footer reassurance on the direct-support paywall"
     },
-    "paywallLoadingPrice": "Loading price",
+    "paywallLoadingPrice": "جارٍ تحميل السعر",
     "@paywallLoadingPrice": {
         "description": "Placeholder shown while the paywall price is loading"
     },
-    "paywallUnavailable": "Unavailable",
+    "paywallUnavailable": "غير متاح",
     "@paywallUnavailable": {
         "description": "Paywall price/button text when purchases are unavailable"
     },
-    "paywallSupportOnce": "Support once",
+    "paywallSupportOnce": "ادعم مرة واحدة",
     "@paywallSupportOnce": {
         "description": "Purchase button label on the direct-support paywall"
     },
-    "paywallRestorePurchase": "Restore purchase",
+    "paywallRestorePurchase": "استعادة الشراء",
     "@paywallRestorePurchase": {
         "description": "Restore button label on the direct-support paywall"
     },
-    "paywallProActiveToast": "Custom Bingo Pro is active.",
+    "paywallProActiveToast": "Custom Bingo Pro نشط.",
     "@paywallProActiveToast": {
         "description": "Toast shown after a successful Pro purchase"
     },
-    "paywallPurchaseInactiveToast": "Purchase finished, but Pro is not active.",
+    "paywallPurchaseInactiveToast": "اكتمل الشراء، لكن Pro غير نشط.",
     "@paywallPurchaseInactiveToast": {
         "description": "Toast shown if a purchase returns without Pro access"
     },
-    "paywallProRestoredToast": "Custom Bingo Pro restored.",
+    "paywallProRestoredToast": "تمت استعادة Custom Bingo Pro.",
     "@paywallProRestoredToast": {
         "description": "Toast shown after restoring Pro access"
     },
-    "paywallNoPurchaseFoundToast": "No Pro purchase found.",
+    "paywallNoPurchaseFoundToast": "لم يتم العثور على شراء Pro.",
     "@paywallNoPurchaseFoundToast": {
         "description": "Toast shown when restore finds no Pro access"
     },
-    "paywallPurchasesUnavailable": "Purchases are unavailable right now.",
+    "paywallPurchasesUnavailable": "المشتريات غير متاحة الآن.",
     "@paywallPurchasesUnavailable": {
         "description": "Fallback error text for a paywall purchase error"
     },
-    "paywallPlatformUnavailable": "Purchases are unavailable on this platform.",
+    "paywallPlatformUnavailable": "المشتريات غير متاحة على هذا النظام.",
     "@paywallPlatformUnavailable": {
         "description": "Fallback paywall text when purchases are not configured for the platform"
     },
-    "paywallCouldNotLoad": "Could not load purchase information.",
+    "paywallCouldNotLoad": "تعذر تحميل معلومات الشراء.",
     "@paywallCouldNotLoad": {
         "description": "Fallback paywall error text for an unknown purchase loading error"
     },
@@ -460,7 +498,7 @@
     "@shareTitle": {
         "description": "Title of the share dialog"
     },
-    "shareDialogPrompt": "How would you like to share?",
+    "shareDialogPrompt": "كيف تريد المشاركة؟",
     "@shareDialogPrompt": {
         "description": "Section header above the two share options"
     },
@@ -468,7 +506,7 @@
     "@shareImageOptionTitle": {
         "description": "Title of the image-share option in the share dialog"
     },
-    "shareImageOptionHelper": "Send a picture of your card. Anyone can see it — even without the app.",
+    "shareImageOptionHelper": "أرسل صورة لبطاقتك. يمكن لأي شخص رؤيتها حتى بدون التطبيق.",
     "@shareImageOptionHelper": {
         "description": "Helper text explaining what 'Share as image' does"
     },
@@ -480,15 +518,15 @@
     "@shareInviteOptionTitle": {
         "description": "Title of the play-together invite option"
     },
-    "shareInviteOptionHelper": "Send this link to your friends who also have this app installed. They get the same card and you can play together.",
+    "shareInviteOptionHelper": "أرسل هذا الرابط إلى أصدقائك الذين لديهم هذا التطبيق أيضًا. سيحصلون على نفس البطاقة ويمكنكم اللعب معًا.",
     "@shareInviteOptionHelper": {
         "description": "Helper text explaining what the invite link does"
     },
-    "shareInviteIncludeMarks": "Include my checkmarks",
+    "shareInviteIncludeMarks": "تضمين علاماتي",
     "@shareInviteIncludeMarks": {
         "description": "Toggle label: include the sender's marks in the invite"
     },
-    "shareInviteIncludeMarksHelper": "When on, your friends will see what you've already crossed off.",
+    "shareInviteIncludeMarksHelper": "عند التفعيل، سيرى أصدقاؤك ما شطبته بالفعل.",
     "@shareInviteIncludeMarksHelper": {
         "description": "Helper text under the include-checkmarks toggle"
     },
@@ -514,15 +552,15 @@
     "@close": {
         "description": "Generic close button"
     },
-    "shareSubject": "Bingo Card",
+    "shareSubject": "بطاقة بينغو",
     "@shareSubject": {
         "description": "Subject/title used by the system share sheet"
     },
-    "importTitle": "A friend shared a bingo card with you",
+    "importTitle": "شارك صديق بطاقة بينغو معك",
     "@importTitle": {
         "description": "Title of the import-card screen shown to the receiver"
     },
-    "importBody": "Add it to your cards so you can play along?",
+    "importBody": "هل تريد إضافتها إلى بطاقاتك لتلعب معه؟",
     "@importBody": {
         "description": "Body of the import-card screen"
     },
@@ -534,7 +572,7 @@
     "@importCancel": {
         "description": "Cancel button on the import-card screen"
     },
-    "importCollisionToast": "You already had a card with this name, so I added it as \"{newName}\".",
+    "importCollisionToast": "كانت لديك بطاقة بهذا الاسم، لذلك أضفتها باسم \"{newName}\".",
     "@importCollisionToast": {
         "description": "Toast shown after silently renaming an imported card to avoid a collision",
         "placeholders": {
@@ -544,11 +582,11 @@
             }
         }
     },
-    "importBadLinkToast": "Sorry, this invite couldn't be opened. Ask your friend to send it again.",
+    "importBadLinkToast": "عذرًا، تعذر فتح هذه الدعوة. اطلب من صديقك إرسالها مرة أخرى.",
     "@importBadLinkToast": {
         "description": "Toast shown when an invite link is malformed"
     },
-    "importOutdatedAppToast": "Update the app to open this invite.",
+    "importOutdatedAppToast": "حدّث التطبيق لفتح هذه الدعوة.",
     "@importOutdatedAppToast": {
         "description": "Toast shown when an invite payload uses a newer schema"
     },
@@ -582,55 +620,55 @@
             }
         }
     },
-    "screenshotCaptionPlaying": "Just a simple app to create bingo board.\n\nNo signup, no ads, fully free to use.",
+    "screenshotCaptionPlaying": "تطبيق بسيط لإنشاء لوح بينغو.\\n\\nبدون تسجيل، بدون إعلانات، ومجاني بالكامل.",
     "@screenshotCaptionPlaying": {
         "description": "Promotional caption for the screenshot showing a played bingo board"
     },
-    "screenshotCaptionCreate": "Literally just 2 screens to create a bingo grid.",
+    "screenshotCaptionCreate": "شاشتان فقط لإنشاء شبكة بينغو.",
     "@screenshotCaptionCreate": {
         "description": "Promotional caption for the screenshot showing the new-board screen"
     },
-    "screenshotCaptionLocked": "That's it.",
+    "screenshotCaptionLocked": "هذا كل شيء.",
     "@screenshotCaptionLocked": {
         "description": "Promotional caption for the screenshot showing the locked board"
     },
-    "screenshotBoardName": "David's Wedding",
+    "screenshotBoardName": "زفاف ديفيد",
     "@screenshotBoardName": {
         "description": "Sample bingo board name used in generated screenshots"
     },
-    "screenshotTilePhoneDuringVows": "Phone during vows",
+    "screenshotTilePhoneDuringVows": "هاتف أثناء الوعود",
     "@screenshotTilePhoneDuringVows": {
         "description": "Sample bingo tile text used in generated screenshots"
     },
-    "screenshotTileChampagneSpilled": "Champagne spilled",
+    "screenshotTileChampagneSpilled": "انسكاب الشمبانيا",
     "@screenshotTileChampagneSpilled": {
         "description": "Sample bingo tile text used in generated screenshots"
     },
-    "screenshotTileSpeechTears": "Speech tears",
+    "screenshotTileSpeechTears": "دموع أثناء الخطاب",
     "@screenshotTileSpeechTears": {
         "description": "Sample bingo tile text used in generated screenshots"
     },
-    "screenshotTileDramaticEntrance": "Dramatic entrance",
+    "screenshotTileDramaticEntrance": "دخول درامي",
     "@screenshotTileDramaticEntrance": {
         "description": "Sample bingo tile text used in generated screenshots"
     },
-    "screenshotTileKidsDanceFloor": "Kids take the dance floor",
+    "screenshotTileKidsDanceFloor": "الأطفال على ساحة الرقص",
     "@screenshotTileKidsDanceFloor": {
         "description": "Sample bingo tile text used in generated screenshots"
     },
-    "screenshotTileGuestToast": "Guest gives a toast",
+    "screenshotTileGuestToast": "ضيف يرفع نخبًا",
     "@screenshotTileGuestToast": {
         "description": "Sample bingo tile text used in generated screenshots"
     },
-    "screenshotTileCrowdClapsEarly": "Crowd claps early",
+    "screenshotTileCrowdClapsEarly": "تصفيق مبكر",
     "@screenshotTileCrowdClapsEarly": {
         "description": "Sample bingo tile text used in generated screenshots"
     },
-    "screenshotTileDjClassic": "DJ plays a classic",
+    "screenshotTileDjClassic": "الدي جي يشغل أغنية كلاسيكية",
     "@screenshotTileDjClassic": {
         "description": "Sample bingo tile text used in generated screenshots"
     },
-    "screenshotTileGroupPhotoChaos": "Group photo chaos",
+    "screenshotTileGroupPhotoChaos": "فوضى صورة جماعية",
     "@screenshotTileGroupPhotoChaos": {
         "description": "Sample bingo tile text used in generated screenshots"
     }

--- a/lib/l10n/arb/app_ar.arb
+++ b/lib/l10n/arb/app_ar.arb
@@ -1,0 +1,637 @@
+{
+    "@@locale": "ar",
+    "newCardTitle": "إنشاء شبكة بنغو جديدة",
+    "@newCardTitle": {
+        "description": "AppBar title of the new-card screen"
+    },
+    "editCardTitle": "تعديل شبكة البنغو",
+    "@editCardTitle": {
+        "description": "AppBar title of the edit-card screen"
+    },
+    "cardNameLabel": "اسم شبكة البنغو *",
+    "@cardNameLabel": {
+        "description": "Label of the card-name text field"
+    },
+    "cardNameHint": "أدخل اسمًا لشبكة البنغو",
+    "@cardNameHint": {
+        "description": "Placeholder hint for the card-name text field"
+    },
+    "createCardButton": "إنشاء شبكة البنغو",
+    "@createCardButton": {
+        "description": "Confirm button on the new-card screen"
+    },
+    "updateCardButton": "تحديث شبكة البنغو",
+    "@updateCardButton": {
+        "description": "Confirm button on the edit-card screen"
+    },
+    "newBoardPreMadeSectionTitle": "Your pre-made items",
+    "@newBoardPreMadeSectionTitle": {
+        "description": "Expandable section title for pre-made items on the new-board screen"
+    },
+    "newBoardPreMadeButton": "Start with pre-made items",
+    "@newBoardPreMadeButton": {
+        "description": "Button that opens pre-made item selection from the new-board screen"
+    },
+    "newBoardPreMadeChangeButton": "Change pre-made items",
+    "@newBoardPreMadeChangeButton": {
+        "description": "Button that reopens pre-made item selection after items have been applied"
+    },
+    "newBoardPreMadeClearButton": "Clear pre-made items",
+    "@newBoardPreMadeClearButton": {
+        "description": "Button that clears applied pre-made entries from the new-board form"
+    },
+    "newBoardPreMadeAppliedCount": "{count} pre-made entries applied",
+    "@newBoardPreMadeAppliedCount": {
+        "description": "Summary of how many pre-made entries are applied to the new-board form",
+        "placeholders": {
+            "count": {
+                "type": "int",
+                "example": "40"
+            }
+        }
+    },
+    "newBoardPreMadeFullSummary": "{used} will be drawn at random for this board.",
+    "@newBoardPreMadeFullSummary": {
+        "description": "Summary when applied pre-made entries can fill the new board",
+        "placeholders": {
+            "used": {
+                "type": "int",
+                "example": "25"
+            }
+        }
+    },
+    "newBoardPreMadePartialSummary": "{used} cells will be filled. {blank} will stay blank.",
+    "@newBoardPreMadePartialSummary": {
+        "description": "Summary when applied pre-made entries are fewer than the board cells",
+        "placeholders": {
+            "used": {
+                "type": "int",
+                "example": "10"
+            },
+            "blank": {
+                "type": "int",
+                "example": "15"
+            }
+        }
+    },
+    "defaultCardName": "بطاقة بنغو",
+    "@defaultCardName": {
+        "description": "Fallback title shown when a card has no name"
+    },
+    "toggleHint": "اضغط مطولًا لوضع علامة على خانة",
+    "@toggleHint": {
+        "description": "Hint banner above the bingo grid"
+    },
+    "editingHintBefore": "Press the lock icon",
+    "@editingHintBefore": {
+        "description": "First half of the hint that explains the lock toggle. The lock icon is rendered between the two halves."
+    },
+    "editingHintAfter": " to make the fields not editable anymore.",
+    "@editingHintAfter": {
+        "description": "Second half of the lock-toggle hint, rendered after the lock icon."
+    },
+    "deleteCardTitle": "Delete Card",
+    "@deleteCardTitle": {
+        "description": "Title of the delete-card confirmation dialog"
+    },
+    "deleteCardConfirm": "Are you sure you want to delete this card?",
+    "@deleteCardConfirm": {
+        "description": "Body of the delete-card confirmation dialog"
+    },
+    "cancel": "إلغاء",
+    "@cancel": {
+        "description": "Generic cancel button"
+    },
+    "delete": "حذف",
+    "@delete": {
+        "description": "Generic delete button"
+    },
+    "shuffleCardTitle": "Shuffle Card",
+    "@shuffleCardTitle": {
+        "description": "Title of the shuffle confirmation dialog"
+    },
+    "shuffleCardConfirm": "Are you sure you want to shuffle this card? All fields will be unchecked, after shuffling.",
+    "@shuffleCardConfirm": {
+        "description": "Body of the shuffle confirmation dialog"
+    },
+    "shuffle": "خلط",
+    "@shuffle": {
+        "description": "Confirm button to shuffle the card"
+    },
+    "ratingPromptTitle": "Do you like Custom Bingo?",
+    "@ratingPromptTitle": {
+        "description": "Title of the dialog shown before asking for an app store review"
+    },
+    "ratingPromptBody": "If so, a quick store review helps others find it.",
+    "@ratingPromptBody": {
+        "description": "Body of the dialog shown before asking for an app store review"
+    },
+    "ratingPromptNo": "Not really",
+    "@ratingPromptNo": {
+        "description": "Dismiss button for the rating prompt dialog"
+    },
+    "ratingPromptYes": "Yes, I like it",
+    "@ratingPromptYes": {
+        "description": "Confirm button that continues to the native app store review flow"
+    },
+    "boardActionShare": "مشاركة",
+    "@boardActionShare": {
+        "description": "Menu item that opens the share dialog from the board action bar"
+    },
+    "boardActionEditBoard": "تعديل اللوحة",
+    "@boardActionEditBoard": {
+        "description": "Menu item that opens the board edit flow from the board action bar"
+    },
+    "boardActionAddPreMadeItems": "Add pre-made items",
+    "@boardActionAddPreMadeItems": {
+        "description": "Debug menu item placeholder for filling a board with pre-made items"
+    },
+    "cellHint": "أدخل نصًا…",
+    "@cellHint": {
+        "description": "Placeholder for an empty bingo cell"
+    },
+    "edit": "تعديل",
+    "@edit": {
+        "description": "Edit menu item in a cell's context menu"
+    },
+    "markDone": "Mark Done",
+    "@markDone": {
+        "description": "Cell context menu item: mark this cell as done"
+    },
+    "markNotDone": "Mark Not Done",
+    "@markNotDone": {
+        "description": "Cell context menu item: clear the done state"
+    },
+    "newCardMenuItem": "لوحة بنغو جديدة",
+    "@newCardMenuItem": {
+        "description": "Menu item that opens the new-card screen"
+    },
+    "yourCardsHeader": "لوحاتك",
+    "@yourCardsHeader": {
+        "description": "Section header in the popup menu listing saved cards"
+    },
+    "settingsHeader": "الإعدادات",
+    "@settingsHeader": {
+        "description": "Section header in the popup menu"
+    },
+    "appearanceMenuItem": "Appearance",
+    "@appearanceMenuItem": {
+        "description": "Menu item that opens the appearance settings screen"
+    },
+    "settingsAppearanceSection": "المظهر",
+    "@settingsAppearanceSection": {
+        "description": "Section title for appearance settings"
+    },
+    "settingsPreferencesSection": "التفضيلات",
+    "@settingsPreferencesSection": {
+        "description": "Section title for general preference settings"
+    },
+    "settingsBoardsSection": "اللوحات",
+    "@settingsBoardsSection": {
+        "description": "Section title for board-related settings"
+    },
+    "settingsHelpSection": "المزيد",
+    "@settingsHelpSection": {
+        "description": "Section title for additional settings, help, and support entries"
+    },
+    "settingsSupportSection": "الدعم",
+    "@settingsSupportSection": {
+        "description": "Section title for supporting the developer"
+    },
+    "themeColorLabel": "لون السمة",
+    "@themeColorLabel": {
+        "description": "Label above the theme color selector in settings"
+    },
+    "themeColorSettingsDescription": "اختر لوحة الألوان المستخدمة في التطبيق.",
+    "@themeColorSettingsDescription": {
+        "description": "Settings helper text for the theme color selector"
+    },
+    "languageSettingsTitle": "اللغة",
+    "@languageSettingsTitle": {
+        "description": "Settings tile title for choosing the app language"
+    },
+    "languageSettingsSelectorLabel": "لغة التطبيق",
+    "@languageSettingsSelectorLabel": {
+        "description": "Label above the language dropdown in settings"
+    },
+    "languageSettingsSystemOption": "إعداد النظام الافتراضي ({language})",
+    "@languageSettingsSystemOption": {
+        "description": "Dropdown option that makes the app follow the phone/system language. The placeholder is the current phone language display name.",
+        "placeholders": {
+            "language": {
+                "type": "String",
+                "example": "Deutsch"
+            }
+        }
+    },
+    "languageSettingsSystemDescription": "يتبع لغة الهاتف: {language}.",
+    "@languageSettingsSystemDescription": {
+        "description": "Settings helper text when no manual app language override is selected. The placeholder is the current phone language display name.",
+        "placeholders": {
+            "language": {
+                "type": "String",
+                "example": "Deutsch"
+            }
+        }
+    },
+    "languageSettingsOverrideDescription": "استخدم هذه اللغة بدلًا من لغة الهاتف.",
+    "@languageSettingsOverrideDescription": {
+        "description": "Settings helper text when a manual app language override is selected"
+    },
+    "darkModeLabel": "الوضع الداكن",
+    "@darkModeLabel": {
+        "description": "Label for the dark mode switch in settings"
+    },
+    "darkModeSettingsDescription": "استخدم واجهة أغمق.",
+    "@darkModeSettingsDescription": {
+        "description": "Settings helper text for the dark mode switch"
+    },
+    "enableConfettiLabel": "قصاصات الاحتفال",
+    "@enableConfettiLabel": {
+        "description": "Label for the confetti preference switch"
+    },
+    "enableConfettiSettingsDescription": "اعرض احتفالًا عند إكمال بنغو.",
+    "@enableConfettiSettingsDescription": {
+        "description": "Settings helper text for the confetti preference switch"
+    },
+    "preMadeTilesTitle": "Pre-made tiles",
+    "@preMadeTilesTitle": {
+        "description": "Title of the pre-made tiles settings screen and menu entry"
+    },
+    "preMadeTilesSettingsDescription": "Create reusable tile text for future boards.",
+    "@preMadeTilesSettingsDescription": {
+        "description": "Settings entry helper text for pre-made tiles"
+    },
+    "preMadeTilesDescription": "Create reusable bingo entries here. When you create a new board, you can add them without typing everything again.",
+    "@preMadeTilesDescription": {
+        "description": "Description shown below the pre-made tiles screen title"
+    },
+    "preMadeTilesSelectMode": "Select",
+    "@preMadeTilesSelectMode": {
+        "description": "Segmented control label for selecting pre-made tiles"
+    },
+    "preMadeTilesEditMode": "Edit",
+    "@preMadeTilesEditMode": {
+        "description": "Segmented control label for editing pre-made tiles"
+    },
+    "preMadeTileHint": "Tile text",
+    "@preMadeTileHint": {
+        "description": "Placeholder for a pre-made tile text field"
+    },
+    "preMadeTilesAdd": "Add tile",
+    "@preMadeTilesAdd": {
+        "description": "Accessible label and tooltip for adding a pre-made tile"
+    },
+    "preMadeTilesDelete": "Delete tile",
+    "@preMadeTilesDelete": {
+        "description": "Accessible label and tooltip for deleting a pre-made tile"
+    },
+    "preMadeTilesSelectAll": "Un/select all",
+    "@preMadeTilesSelectAll": {
+        "description": "Checkbox label for toggling all pre-made tile selections"
+    },
+    "preMadeTilesSelectNone": "Select none",
+    "@preMadeTilesSelectNone": {
+        "description": "Button label for clearing all selected pre-made tiles"
+    },
+    "preMadeTilesApply": "Apply",
+    "@preMadeTilesApply": {
+        "description": "Button label for applying selected pre-made tiles to a board"
+    },
+    "preMadeTilesReplaceItems": "Replace items",
+    "@preMadeTilesReplaceItems": {
+        "description": "Button label for replacing current board items with selected pre-made items"
+    },
+    "preMadeTilesFillItems": "Fill items",
+    "@preMadeTilesFillItems": {
+        "description": "Button label for filling empty board items with selected pre-made items"
+    },
+    "preMadeTilesBoardActionHelp": "Replace swaps the board entries with a random draw from your selection. Fill only adds items to empty tiles. On odd boards, the center tile stays in place.",
+    "@preMadeTilesBoardActionHelp": {
+        "description": "Helper text explaining replace and fill actions for pre-made items on an existing board"
+    },
+    "preMadeTilesSelectedCount": "{selected} / {total} selected",
+    "@preMadeTilesSelectedCount": {
+        "description": "Count of selected pre-made tiles",
+        "placeholders": {
+            "selected": {
+                "type": "int",
+                "example": "12"
+            },
+            "total": {
+                "type": "int",
+                "example": "24"
+            }
+        }
+    },
+    "preMadeTilesEmptyTitle": "No tiles yet",
+    "@preMadeTilesEmptyTitle": {
+        "description": "Empty-state title for the pre-made tiles screen"
+    },
+    "preMadeTilesEmptyBody": "Add a tile to start building a reusable list.",
+    "@preMadeTilesEmptyBody": {
+        "description": "Empty-state helper text for the pre-made tiles screen"
+    },
+    "proposeFeatures": "Propose Features",
+    "@proposeFeatures": {
+        "description": "Menu item that opens the UserOrient feedback board"
+    },
+    "proposeFeaturesSettingsDescription": "Vote on ideas and suggest what to build next.",
+    "@proposeFeaturesSettingsDescription": {
+        "description": "Settings helper text for the feature request entry"
+    },
+    "supportMeDirectly": "Support the developer",
+    "@supportMeDirectly": {
+        "description": "Menu item that opens the direct-support paywall"
+    },
+    "supportMeDirectlySettingsDescription": "Help fund development and keep the app improving.",
+    "@supportMeDirectlySettingsDescription": {
+        "description": "Settings helper text for the direct support entry"
+    },
+    "supportCarouselProTitle": "Support Custom Bingo",
+    "@supportCarouselProTitle": {
+        "description": "Title of the home-screen support carousel item that opens the paywall"
+    },
+    "supportCarouselProSubtitle": "Unlock bonus colors and help keep the app independent.",
+    "@supportCarouselProSubtitle": {
+        "description": "Subtitle of the home-screen support carousel item that opens the paywall"
+    },
+    "supportCarouselRateTitle": "Enjoying the app?",
+    "@supportCarouselRateTitle": {
+        "description": "Title of the home-screen support carousel item that asks for a store review"
+    },
+    "supportCarouselRateSubtitle": "A quick review helps more people find Custom Bingo.",
+    "@supportCarouselRateSubtitle": {
+        "description": "Subtitle of the home-screen support carousel item that asks for a store review"
+    },
+    "rateTheApp": "Rate the app",
+    "@rateTheApp": {
+        "description": "Settings entry that opens the native store rating dialog"
+    },
+    "rateTheAppSettingsDescription": "Open the store rating prompt.",
+    "@rateTheAppSettingsDescription": {
+        "description": "Settings helper text for the app rating entry"
+    },
+    "contactMe": "Contact me",
+    "@contactMe": {
+        "description": "Settings entry that opens an email composer"
+    },
+    "contactMeSettingsDescription": "Send feedback, questions, or bug reports by email.",
+    "@contactMeSettingsDescription": {
+        "description": "Settings helper text for the contact email entry"
+    },
+    "paywallTitle": "Support Custom Bingo",
+    "@paywallTitle": {
+        "description": "AppBar title of the direct-support paywall"
+    },
+    "paywallThankYouTitle": "Thank you",
+    "@paywallThankYouTitle": {
+        "description": "Paywall title shown after Pro access is active"
+    },
+    "paywallSupportTitle": "Support Custom Bingo",
+    "@paywallSupportTitle": {
+        "description": "Main title on the direct-support paywall"
+    },
+    "paywallSupportBody": "This purchase supports me, the developer, directly. You get my gratitude and a few small bonus things for your boards.",
+    "@paywallSupportBody": {
+        "description": "Main body copy on the direct-support paywall"
+    },
+    "paywallBonusGratitude": "My gratitude, sincerely.",
+    "@paywallBonusGratitude": {
+        "description": "First benefit line on the direct-support paywall"
+    },
+    "paywallBonusColors": "A few extra board colors.",
+    "@paywallBonusColors": {
+        "description": "Second benefit line on the direct-support paywall"
+    },
+    "paywallBonusExtras": "Small supporter extras over time.",
+    "@paywallBonusExtras": {
+        "description": "Third benefit line on the direct-support paywall"
+    },
+    "paywallFreeForever": "No one ever needs to pay for this app. Custom Bingo stays usable for everyone.",
+    "@paywallFreeForever": {
+        "description": "Footer reassurance on the direct-support paywall"
+    },
+    "paywallLoadingPrice": "Loading price",
+    "@paywallLoadingPrice": {
+        "description": "Placeholder shown while the paywall price is loading"
+    },
+    "paywallUnavailable": "Unavailable",
+    "@paywallUnavailable": {
+        "description": "Paywall price/button text when purchases are unavailable"
+    },
+    "paywallSupportOnce": "Support once",
+    "@paywallSupportOnce": {
+        "description": "Purchase button label on the direct-support paywall"
+    },
+    "paywallRestorePurchase": "Restore purchase",
+    "@paywallRestorePurchase": {
+        "description": "Restore button label on the direct-support paywall"
+    },
+    "paywallProActiveToast": "Custom Bingo Pro is active.",
+    "@paywallProActiveToast": {
+        "description": "Toast shown after a successful Pro purchase"
+    },
+    "paywallPurchaseInactiveToast": "Purchase finished, but Pro is not active.",
+    "@paywallPurchaseInactiveToast": {
+        "description": "Toast shown if a purchase returns without Pro access"
+    },
+    "paywallProRestoredToast": "Custom Bingo Pro restored.",
+    "@paywallProRestoredToast": {
+        "description": "Toast shown after restoring Pro access"
+    },
+    "paywallNoPurchaseFoundToast": "No Pro purchase found.",
+    "@paywallNoPurchaseFoundToast": {
+        "description": "Toast shown when restore finds no Pro access"
+    },
+    "paywallPurchasesUnavailable": "Purchases are unavailable right now.",
+    "@paywallPurchasesUnavailable": {
+        "description": "Fallback error text for a paywall purchase error"
+    },
+    "paywallPlatformUnavailable": "Purchases are unavailable on this platform.",
+    "@paywallPlatformUnavailable": {
+        "description": "Fallback paywall text when purchases are not configured for the platform"
+    },
+    "paywallCouldNotLoad": "Could not load purchase information.",
+    "@paywallCouldNotLoad": {
+        "description": "Fallback paywall error text for an unknown purchase loading error"
+    },
+    "shareTitle": "مشاركة بطاقة البنغو",
+    "@shareTitle": {
+        "description": "Title of the share dialog"
+    },
+    "shareDialogPrompt": "How would you like to share?",
+    "@shareDialogPrompt": {
+        "description": "Section header above the two share options"
+    },
+    "shareImageOptionTitle": "مشاركة كصورة",
+    "@shareImageOptionTitle": {
+        "description": "Title of the image-share option in the share dialog"
+    },
+    "shareImageOptionHelper": "Send a picture of your card. Anyone can see it — even without the app.",
+    "@shareImageOptionHelper": {
+        "description": "Helper text explaining what 'Share as image' does"
+    },
+    "shareImageOptionButton": "مشاركة الصورة",
+    "@shareImageOptionButton": {
+        "description": "Confirm button on the image-share option"
+    },
+    "shareInviteOptionTitle": "دعوة الأصدقاء للعب",
+    "@shareInviteOptionTitle": {
+        "description": "Title of the play-together invite option"
+    },
+    "shareInviteOptionHelper": "Send this link to your friends who also have this app installed. They get the same card and you can play together.",
+    "@shareInviteOptionHelper": {
+        "description": "Helper text explaining what the invite link does"
+    },
+    "shareInviteIncludeMarks": "Include my checkmarks",
+    "@shareInviteIncludeMarks": {
+        "description": "Toggle label: include the sender's marks in the invite"
+    },
+    "shareInviteIncludeMarksHelper": "When on, your friends will see what you've already crossed off.",
+    "@shareInviteIncludeMarksHelper": {
+        "description": "Helper text under the include-checkmarks toggle"
+    },
+    "shareInviteOptionButton": "إرسال الدعوة",
+    "@shareInviteOptionButton": {
+        "description": "Confirm button on the invite-link option"
+    },
+    "shareInviteText": "العب \"{name}\" معي! افتحه في التطبيق:\n{link}",
+    "@shareInviteText": {
+        "description": "Body text passed to the system share sheet alongside the invite link",
+        "placeholders": {
+            "name": {
+                "type": "String",
+                "example": "Dateline BINGO"
+            },
+            "link": {
+                "type": "String",
+                "example": "https://bingogrid.web.app/import?d=…"
+            }
+        }
+    },
+    "close": "إغلاق",
+    "@close": {
+        "description": "Generic close button"
+    },
+    "shareSubject": "Bingo Card",
+    "@shareSubject": {
+        "description": "Subject/title used by the system share sheet"
+    },
+    "importTitle": "A friend shared a bingo card with you",
+    "@importTitle": {
+        "description": "Title of the import-card screen shown to the receiver"
+    },
+    "importBody": "Add it to your cards so you can play along?",
+    "@importBody": {
+        "description": "Body of the import-card screen"
+    },
+    "importConfirm": "إضافة إلى بطاقاتي",
+    "@importConfirm": {
+        "description": "Confirm button on the import-card screen"
+    },
+    "importCancel": "ليس الآن",
+    "@importCancel": {
+        "description": "Cancel button on the import-card screen"
+    },
+    "importCollisionToast": "You already had a card with this name, so I added it as \"{newName}\".",
+    "@importCollisionToast": {
+        "description": "Toast shown after silently renaming an imported card to avoid a collision",
+        "placeholders": {
+            "newName": {
+                "type": "String",
+                "example": "Dateline BINGO (2)"
+            }
+        }
+    },
+    "importBadLinkToast": "Sorry, this invite couldn't be opened. Ask your friend to send it again.",
+    "@importBadLinkToast": {
+        "description": "Toast shown when an invite link is malformed"
+    },
+    "importOutdatedAppToast": "Update the app to open this invite.",
+    "@importOutdatedAppToast": {
+        "description": "Toast shown when an invite payload uses a newer schema"
+    },
+    "toastInfo": "معلومة",
+    "@toastInfo": {
+        "description": "Title of an informational toast"
+    },
+    "toastSuccess": "نجاح",
+    "@toastSuccess": {
+        "description": "Title of a success toast"
+    },
+    "toastError": "خطأ",
+    "@toastError": {
+        "description": "Title of an error toast"
+    },
+    "lastChangeNever": "آخر تغيير: أبدًا",
+    "@lastChangeNever": {
+        "description": "Footer line shown when a card has never been edited"
+    },
+    "lastChange": "آخر تغيير: {date} {time}",
+    "@lastChange": {
+        "description": "Footer line showing when the card was last edited",
+        "placeholders": {
+            "date": {
+                "type": "String",
+                "example": "5.5.2026"
+            },
+            "time": {
+                "type": "String",
+                "example": "14:30"
+            }
+        }
+    },
+    "screenshotCaptionPlaying": "Just a simple app to create bingo board.\n\nNo signup, no ads, fully free to use.",
+    "@screenshotCaptionPlaying": {
+        "description": "Promotional caption for the screenshot showing a played bingo board"
+    },
+    "screenshotCaptionCreate": "Literally just 2 screens to create a bingo grid.",
+    "@screenshotCaptionCreate": {
+        "description": "Promotional caption for the screenshot showing the new-board screen"
+    },
+    "screenshotCaptionLocked": "That's it.",
+    "@screenshotCaptionLocked": {
+        "description": "Promotional caption for the screenshot showing the locked board"
+    },
+    "screenshotBoardName": "David's Wedding",
+    "@screenshotBoardName": {
+        "description": "Sample bingo board name used in generated screenshots"
+    },
+    "screenshotTilePhoneDuringVows": "Phone during vows",
+    "@screenshotTilePhoneDuringVows": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileChampagneSpilled": "Champagne spilled",
+    "@screenshotTileChampagneSpilled": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileSpeechTears": "Speech tears",
+    "@screenshotTileSpeechTears": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileDramaticEntrance": "Dramatic entrance",
+    "@screenshotTileDramaticEntrance": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileKidsDanceFloor": "Kids take the dance floor",
+    "@screenshotTileKidsDanceFloor": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileGuestToast": "Guest gives a toast",
+    "@screenshotTileGuestToast": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileCrowdClapsEarly": "Crowd claps early",
+    "@screenshotTileCrowdClapsEarly": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileDjClassic": "DJ plays a classic",
+    "@screenshotTileDjClassic": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileGroupPhotoChaos": "Group photo chaos",
+    "@screenshotTileGroupPhotoChaos": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    }
+}

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -68,6 +68,21 @@
     "settingsSupportSection": "Unterstützen",
     "themeColorLabel": "Themenfarbe",
     "themeColorSettingsDescription": "Wähle die Farbpalette für die App.",
+    "languageSettingsTitle": "Sprache",
+    "languageSettingsSelectorLabel": "App-Sprache",
+    "languageSettingsSystemOption": "Systemstandard ({language})",
+    "@languageSettingsSystemOption": {
+        "placeholders": {
+            "language": { "type": "String" }
+        }
+    },
+    "languageSettingsSystemDescription": "Folgt deiner Telefonsprache: {language}.",
+    "@languageSettingsSystemDescription": {
+        "placeholders": {
+            "language": { "type": "String" }
+        }
+    },
+    "languageSettingsOverrideDescription": "Diese Sprache statt der Telefonsprache verwenden.",
     "darkModeLabel": "Dunkler Modus",
     "darkModeSettingsDescription": "Verwende eine dunklere Oberfläche.",
     "enableConfettiLabel": "Konfetti",

--- a/lib/l10n/arb/app_de.arb
+++ b/lib/l10n/arb/app_de.arb
@@ -1,6 +1,5 @@
 {
     "@@locale": "de",
-
     "newCardTitle": "Neues Bingo erstellen",
     "editCardTitle": "Bingo bearbeiten",
     "cardNameLabel": "Name des Bingos *",
@@ -14,33 +13,38 @@
     "newBoardPreMadeAppliedCount": "{count} vorbereitete Einträge angewendet",
     "@newBoardPreMadeAppliedCount": {
         "placeholders": {
-            "count": { "type": "int" }
+            "count": {
+                "type": "int"
+            }
         }
     },
     "newBoardPreMadeFullSummary": "{used} werden zufällig für dieses Board gezogen.",
     "@newBoardPreMadeFullSummary": {
         "placeholders": {
-            "used": { "type": "int" }
+            "used": {
+                "type": "int"
+            }
         }
     },
     "newBoardPreMadePartialSummary": "{used} Felder werden gefüllt. {blank} bleiben leer.",
     "@newBoardPreMadePartialSummary": {
         "placeholders": {
-            "used": { "type": "int" },
-            "blank": { "type": "int" }
+            "used": {
+                "type": "int"
+            },
+            "blank": {
+                "type": "int"
+            }
         }
     },
     "defaultCardName": "Bingo-Karte",
-
     "toggleHint": "Lange drücken, um ein Feld zu markieren",
     "editingHintBefore": "Drücke auf das Schloss-Symbol",
     "editingHintAfter": ", damit die Felder nicht mehr bearbeitbar sind.",
-
     "deleteCardTitle": "Karte löschen",
     "deleteCardConfirm": "Möchtest du diese Karte wirklich löschen?",
     "cancel": "Abbrechen",
     "delete": "Löschen",
-
     "shuffleCardTitle": "Karte mischen",
     "shuffleCardConfirm": "Möchtest du die Karte wirklich mischen? Alle Markierungen werden danach zurückgesetzt.",
     "shuffle": "Mischen",
@@ -51,19 +55,46 @@
     "boardActionShare": "Teilen",
     "boardActionEditBoard": "Board bearbeiten",
     "boardActionAddPreMadeItems": "Vorbereitete Einträge hinzufügen",
-
     "cellHint": "Text eingeben…",
     "edit": "Bearbeiten",
     "markDone": "Als erledigt markieren",
     "markNotDone": "Markierung entfernen",
-
     "newCardMenuItem": "Neues Bingo",
+    "allBoardsMenuItem": "Alle Boards",
     "yourCardsHeader": "Deine Bingos",
+    "noBoardsYet": "Noch keine Boards",
+    "pageNotFoundTitle": "Seite nicht gefunden",
+    "@pageNotFoundTitle": {
+        "description": "Title shown on the fallback route when a page cannot be found"
+    },
+    "homeButton": "Startseite",
+    "@homeButton": {
+        "description": "Button that navigates back to the home screen"
+    },
+    "revenueCatUserIdLabel": "RevenueCat-Benutzer-ID: {userId}",
+    "@revenueCatUserIdLabel": {
+        "description": "Debug settings label showing the RevenueCat user id",
+        "placeholders": {
+            "userId": {
+                "type": "String",
+                "example": "abc123"
+            }
+        }
+    },
+    "copyRevenueCatUserIdTooltip": "RevenueCat-Benutzer-ID kopieren",
+    "@copyRevenueCatUserIdTooltip": {
+        "description": "Tooltip for copying the RevenueCat user id from debug settings"
+    },
+    "revenueCatUserIdCopiedToast": "RevenueCat-Benutzer-ID kopiert.",
+    "@revenueCatUserIdCopiedToast": {
+        "description": "Toast shown after copying the RevenueCat user id"
+    },
     "settingsHeader": "Einstellungen",
+    "clearSettingsMenuItem": "Einstellungen löschen",
     "appearanceMenuItem": "Design",
     "settingsAppearanceSection": "Design",
     "settingsPreferencesSection": "Einstellungen",
-    "settingsBoardsSection": "Boards",
+    "settingsBoardsSection": "Bingo-Boards",
     "settingsHelpSection": "Mehr",
     "settingsSupportSection": "Unterstützen",
     "themeColorLabel": "Themenfarbe",
@@ -73,13 +104,17 @@
     "languageSettingsSystemOption": "Systemstandard ({language})",
     "@languageSettingsSystemOption": {
         "placeholders": {
-            "language": { "type": "String" }
+            "language": {
+                "type": "String"
+            }
         }
     },
     "languageSettingsSystemDescription": "Folgt deiner Telefonsprache: {language}.",
     "@languageSettingsSystemDescription": {
         "placeholders": {
-            "language": { "type": "String" }
+            "language": {
+                "type": "String"
+            }
         }
     },
     "languageSettingsOverrideDescription": "Diese Sprache statt der Telefonsprache verwenden.",
@@ -104,8 +139,12 @@
     "preMadeTilesSelectedCount": "{selected} / {total} ausgewählt",
     "@preMadeTilesSelectedCount": {
         "placeholders": {
-            "selected": { "type": "int" },
-            "total": { "type": "int" }
+            "selected": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
         }
     },
     "preMadeTilesEmptyTitle": "Noch keine Felder",
@@ -141,14 +180,11 @@
     "paywallPurchasesUnavailable": "Käufe sind gerade nicht verfügbar.",
     "paywallPlatformUnavailable": "Käufe sind auf dieser Plattform nicht verfügbar.",
     "paywallCouldNotLoad": "Kaufinformationen konnten nicht geladen werden.",
-
     "shareTitle": "Bingo-Karte teilen",
     "shareDialogPrompt": "Wie möchtest du teilen?",
-
     "shareImageOptionTitle": "Als Bild teilen",
     "shareImageOptionHelper": "Schicke ein Bild deiner Karte. Jeder kann es sehen, auch ohne die App.",
     "shareImageOptionButton": "Bild teilen",
-
     "shareInviteOptionTitle": "Freunde zum Mitspielen einladen",
     "shareInviteOptionHelper": "Schicke diesen Link an deine Freunde, die diese App auch installiert haben. Sie bekommen die gleiche Karte und ihr könnt zusammen spielen.",
     "shareInviteIncludeMarks": "Meine Markierungen mitsenden",
@@ -157,14 +193,16 @@
     "shareInviteText": "Spiel „{name}\" mit mir! In der App öffnen:\n{link}",
     "@shareInviteText": {
         "placeholders": {
-            "name": { "type": "String" },
-            "link": { "type": "String" }
+            "name": {
+                "type": "String"
+            },
+            "link": {
+                "type": "String"
+            }
         }
     },
-
     "close": "Schließen",
     "shareSubject": "Bingo-Karte",
-
     "importTitle": "Ein Freund hat dir eine Bingo-Karte geschickt",
     "importBody": "Zu deinen Karten hinzufügen, damit ihr zusammen spielen könnt?",
     "importConfirm": "Zu meinen Karten hinzufügen",
@@ -172,25 +210,28 @@
     "importCollisionToast": "Du hattest schon eine Karte mit diesem Namen — ich habe sie als „{newName}\" hinzugefügt.",
     "@importCollisionToast": {
         "placeholders": {
-            "newName": { "type": "String" }
+            "newName": {
+                "type": "String"
+            }
         }
     },
     "importBadLinkToast": "Diese Einladung konnte nicht geöffnet werden. Bitte deinen Freund, sie noch einmal zu schicken.",
     "importOutdatedAppToast": "Aktualisiere die App, um diese Einladung zu öffnen.",
-
-    "toastInfo": "Info",
+    "toastInfo": "Hinweis",
     "toastSuccess": "Erfolg",
     "toastError": "Fehler",
-
     "lastChangeNever": "Letzte Änderung: Nie",
     "lastChange": "Letzte Änderung: {date} {time}",
     "@lastChange": {
         "placeholders": {
-            "date": { "type": "String" },
-            "time": { "type": "String" }
+            "date": {
+                "type": "String"
+            },
+            "time": {
+                "type": "String"
+            }
         }
     },
-
     "screenshotCaptionPlaying": "Eine einfache App, um Bingo-Felder zu erstellen.\n\nOhne Anmeldung, ohne Werbung, vollständig kostenlos nutzbar.",
     "screenshotCaptionCreate": "Nur zwei Bildschirme, um dein Bingo-Raster anzulegen.",
     "screenshotCaptionLocked": "Das war es.",

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -1,463 +1,675 @@
 {
     "@@locale": "en",
-
     "newCardTitle": "Create New Bingo Grid",
-    "@newCardTitle": { "description": "AppBar title of the new-card screen" },
-
+    "@newCardTitle": {
+        "description": "AppBar title of the new-card screen"
+    },
     "editCardTitle": "Edit Bingo Grid",
-    "@editCardTitle": { "description": "AppBar title of the edit-card screen" },
-
+    "@editCardTitle": {
+        "description": "AppBar title of the edit-card screen"
+    },
     "cardNameLabel": "Bingo Grid Name *",
-    "@cardNameLabel": { "description": "Label of the card-name text field" },
-
+    "@cardNameLabel": {
+        "description": "Label of the card-name text field"
+    },
     "cardNameHint": "Enter a name for your bingo grid",
-    "@cardNameHint": { "description": "Placeholder hint for the card-name text field" },
-
+    "@cardNameHint": {
+        "description": "Placeholder hint for the card-name text field"
+    },
     "createCardButton": "Create Bingo Grid",
-    "@createCardButton": { "description": "Confirm button on the new-card screen" },
-
+    "@createCardButton": {
+        "description": "Confirm button on the new-card screen"
+    },
     "updateCardButton": "Update Bingo Grid",
-    "@updateCardButton": { "description": "Confirm button on the edit-card screen" },
-
+    "@updateCardButton": {
+        "description": "Confirm button on the edit-card screen"
+    },
     "newBoardPreMadeSectionTitle": "Your pre-made items",
-    "@newBoardPreMadeSectionTitle": { "description": "Expandable section title for pre-made items on the new-board screen" },
-
+    "@newBoardPreMadeSectionTitle": {
+        "description": "Expandable section title for pre-made items on the new-board screen"
+    },
     "newBoardPreMadeButton": "Start with pre-made items",
-    "@newBoardPreMadeButton": { "description": "Button that opens pre-made item selection from the new-board screen" },
-
+    "@newBoardPreMadeButton": {
+        "description": "Button that opens pre-made item selection from the new-board screen"
+    },
     "newBoardPreMadeChangeButton": "Change pre-made items",
-    "@newBoardPreMadeChangeButton": { "description": "Button that reopens pre-made item selection after items have been applied" },
-
+    "@newBoardPreMadeChangeButton": {
+        "description": "Button that reopens pre-made item selection after items have been applied"
+    },
     "newBoardPreMadeClearButton": "Clear pre-made items",
-    "@newBoardPreMadeClearButton": { "description": "Button that clears applied pre-made entries from the new-board form" },
-
+    "@newBoardPreMadeClearButton": {
+        "description": "Button that clears applied pre-made entries from the new-board form"
+    },
     "newBoardPreMadeAppliedCount": "{count} pre-made entries applied",
     "@newBoardPreMadeAppliedCount": {
         "description": "Summary of how many pre-made entries are applied to the new-board form",
         "placeholders": {
-            "count": { "type": "int", "example": "40" }
+            "count": {
+                "type": "int",
+                "example": "40"
+            }
         }
     },
-
     "newBoardPreMadeFullSummary": "{used} will be drawn at random for this board.",
     "@newBoardPreMadeFullSummary": {
         "description": "Summary when applied pre-made entries can fill the new board",
         "placeholders": {
-            "used": { "type": "int", "example": "25" }
+            "used": {
+                "type": "int",
+                "example": "25"
+            }
         }
     },
-
     "newBoardPreMadePartialSummary": "{used} cells will be filled. {blank} will stay blank.",
     "@newBoardPreMadePartialSummary": {
         "description": "Summary when applied pre-made entries are fewer than the board cells",
         "placeholders": {
-            "used": { "type": "int", "example": "10" },
-            "blank": { "type": "int", "example": "15" }
+            "used": {
+                "type": "int",
+                "example": "10"
+            },
+            "blank": {
+                "type": "int",
+                "example": "15"
+            }
         }
     },
-
     "defaultCardName": "Bingo Card",
-    "@defaultCardName": { "description": "Fallback title shown when a card has no name" },
-
+    "@defaultCardName": {
+        "description": "Fallback title shown when a card has no name"
+    },
     "toggleHint": "Press long to mark a field as checked",
-    "@toggleHint": { "description": "Hint banner above the bingo grid" },
-
+    "@toggleHint": {
+        "description": "Hint banner above the bingo grid"
+    },
     "editingHintBefore": "Press the lock icon",
-    "@editingHintBefore": { "description": "First half of the hint that explains the lock toggle. The lock icon is rendered between the two halves." },
-
+    "@editingHintBefore": {
+        "description": "First half of the hint that explains the lock toggle. The lock icon is rendered between the two halves."
+    },
     "editingHintAfter": " to make the fields not editable anymore.",
-    "@editingHintAfter": { "description": "Second half of the lock-toggle hint, rendered after the lock icon." },
-
+    "@editingHintAfter": {
+        "description": "Second half of the lock-toggle hint, rendered after the lock icon."
+    },
     "deleteCardTitle": "Delete Card",
-    "@deleteCardTitle": { "description": "Title of the delete-card confirmation dialog" },
-
+    "@deleteCardTitle": {
+        "description": "Title of the delete-card confirmation dialog"
+    },
     "deleteCardConfirm": "Are you sure you want to delete this card?",
-    "@deleteCardConfirm": { "description": "Body of the delete-card confirmation dialog" },
-
+    "@deleteCardConfirm": {
+        "description": "Body of the delete-card confirmation dialog"
+    },
     "cancel": "Cancel",
-    "@cancel": { "description": "Generic cancel button" },
-
+    "@cancel": {
+        "description": "Generic cancel button"
+    },
     "delete": "Delete",
-    "@delete": { "description": "Generic delete button" },
-
+    "@delete": {
+        "description": "Generic delete button"
+    },
     "shuffleCardTitle": "Shuffle Card",
-    "@shuffleCardTitle": { "description": "Title of the shuffle confirmation dialog" },
-
+    "@shuffleCardTitle": {
+        "description": "Title of the shuffle confirmation dialog"
+    },
     "shuffleCardConfirm": "Are you sure you want to shuffle this card? All fields will be unchecked, after shuffling.",
-    "@shuffleCardConfirm": { "description": "Body of the shuffle confirmation dialog" },
-
+    "@shuffleCardConfirm": {
+        "description": "Body of the shuffle confirmation dialog"
+    },
     "shuffle": "Shuffle",
-    "@shuffle": { "description": "Confirm button to shuffle the card" },
-
+    "@shuffle": {
+        "description": "Confirm button to shuffle the card"
+    },
     "ratingPromptTitle": "Do you like Custom Bingo?",
-    "@ratingPromptTitle": { "description": "Title of the dialog shown before asking for an app store review" },
-
+    "@ratingPromptTitle": {
+        "description": "Title of the dialog shown before asking for an app store review"
+    },
     "ratingPromptBody": "If so, a quick store review helps others find it.",
-    "@ratingPromptBody": { "description": "Body of the dialog shown before asking for an app store review" },
-
+    "@ratingPromptBody": {
+        "description": "Body of the dialog shown before asking for an app store review"
+    },
     "ratingPromptNo": "Not really",
-    "@ratingPromptNo": { "description": "Dismiss button for the rating prompt dialog" },
-
+    "@ratingPromptNo": {
+        "description": "Dismiss button for the rating prompt dialog"
+    },
     "ratingPromptYes": "Yes, I like it",
-    "@ratingPromptYes": { "description": "Confirm button that continues to the native app store review flow" },
-
+    "@ratingPromptYes": {
+        "description": "Confirm button that continues to the native app store review flow"
+    },
     "boardActionShare": "Share",
-    "@boardActionShare": { "description": "Menu item that opens the share dialog from the board action bar" },
-
+    "@boardActionShare": {
+        "description": "Menu item that opens the share dialog from the board action bar"
+    },
     "boardActionEditBoard": "Edit board",
-    "@boardActionEditBoard": { "description": "Menu item that opens the board edit flow from the board action bar" },
-
+    "@boardActionEditBoard": {
+        "description": "Menu item that opens the board edit flow from the board action bar"
+    },
     "boardActionAddPreMadeItems": "Add pre-made items",
-    "@boardActionAddPreMadeItems": { "description": "Debug menu item placeholder for filling a board with pre-made items" },
-
+    "@boardActionAddPreMadeItems": {
+        "description": "Debug menu item placeholder for filling a board with pre-made items"
+    },
     "cellHint": "Enter text…",
-    "@cellHint": { "description": "Placeholder for an empty bingo cell" },
-
+    "@cellHint": {
+        "description": "Placeholder for an empty bingo cell"
+    },
     "edit": "Edit",
-    "@edit": { "description": "Edit menu item in a cell's context menu" },
-
+    "@edit": {
+        "description": "Edit menu item in a cell's context menu"
+    },
     "markDone": "Mark Done",
-    "@markDone": { "description": "Cell context menu item: mark this cell as done" },
-
+    "@markDone": {
+        "description": "Cell context menu item: mark this cell as done"
+    },
     "markNotDone": "Mark Not Done",
-    "@markNotDone": { "description": "Cell context menu item: clear the done state" },
-
+    "@markNotDone": {
+        "description": "Cell context menu item: clear the done state"
+    },
     "newCardMenuItem": "New bingo board",
-    "@newCardMenuItem": { "description": "Menu item that opens the new-card screen" },
-
+    "@newCardMenuItem": {
+        "description": "Menu item that opens the new-card screen"
+    },
+    "allBoardsMenuItem": "All boards",
+    "@allBoardsMenuItem": {
+        "description": "Menu item that opens the list of all saved boards"
+    },
     "yourCardsHeader": "Your Boards",
-    "@yourCardsHeader": { "description": "Section header in the popup menu listing saved cards" },
-
+    "@yourCardsHeader": {
+        "description": "Section header in the popup menu listing saved cards"
+    },
+    "noBoardsYet": "No boards yet",
+    "@noBoardsYet": {
+        "description": "Empty-state title shown when there are no saved boards"
+    },
+    "pageNotFoundTitle": "Page Not Found",
+    "@pageNotFoundTitle": {
+        "description": "Title shown on the fallback route when a page cannot be found"
+    },
+    "homeButton": "Home",
+    "@homeButton": {
+        "description": "Button that navigates back to the home screen"
+    },
+    "revenueCatUserIdLabel": "RevenueCat user id: {userId}",
+    "@revenueCatUserIdLabel": {
+        "description": "Debug settings label showing the RevenueCat user id",
+        "placeholders": {
+            "userId": {
+                "type": "String",
+                "example": "abc123"
+            }
+        }
+    },
+    "copyRevenueCatUserIdTooltip": "Copy RevenueCat user id",
+    "@copyRevenueCatUserIdTooltip": {
+        "description": "Tooltip for copying the RevenueCat user id from debug settings"
+    },
+    "revenueCatUserIdCopiedToast": "RevenueCat user id copied.",
+    "@revenueCatUserIdCopiedToast": {
+        "description": "Toast shown after copying the RevenueCat user id"
+    },
     "settingsHeader": "Settings",
-    "@settingsHeader": { "description": "Section header in the popup menu" },
-
+    "@settingsHeader": {
+        "description": "Section header in the popup menu"
+    },
+    "clearSettingsMenuItem": "Clear Settings",
+    "@clearSettingsMenuItem": {
+        "description": "Debug menu item that clears saved settings"
+    },
     "appearanceMenuItem": "Appearance",
-    "@appearanceMenuItem": { "description": "Menu item that opens the appearance settings screen" },
-
+    "@appearanceMenuItem": {
+        "description": "Menu item that opens the appearance settings screen"
+    },
     "settingsAppearanceSection": "Appearance",
-    "@settingsAppearanceSection": { "description": "Section title for appearance settings" },
-
+    "@settingsAppearanceSection": {
+        "description": "Section title for appearance settings"
+    },
     "settingsPreferencesSection": "Preferences",
-    "@settingsPreferencesSection": { "description": "Section title for general preference settings" },
-
+    "@settingsPreferencesSection": {
+        "description": "Section title for general preference settings"
+    },
     "settingsBoardsSection": "Boards",
-    "@settingsBoardsSection": { "description": "Section title for board-related settings" },
-
+    "@settingsBoardsSection": {
+        "description": "Section title for board-related settings"
+    },
     "settingsHelpSection": "More",
-    "@settingsHelpSection": { "description": "Section title for additional settings, help, and support entries" },
-
+    "@settingsHelpSection": {
+        "description": "Section title for additional settings, help, and support entries"
+    },
     "settingsSupportSection": "Support",
-    "@settingsSupportSection": { "description": "Section title for supporting the developer" },
-
+    "@settingsSupportSection": {
+        "description": "Section title for supporting the developer"
+    },
     "themeColorLabel": "Theme color",
-    "@themeColorLabel": { "description": "Label above the theme color selector in settings" },
-
+    "@themeColorLabel": {
+        "description": "Label above the theme color selector in settings"
+    },
     "themeColorSettingsDescription": "Choose the palette used across the app.",
-    "@themeColorSettingsDescription": { "description": "Settings helper text for the theme color selector" },
-
+    "@themeColorSettingsDescription": {
+        "description": "Settings helper text for the theme color selector"
+    },
     "languageSettingsTitle": "Language",
-    "@languageSettingsTitle": { "description": "Settings tile title for choosing the app language" },
-
+    "@languageSettingsTitle": {
+        "description": "Settings tile title for choosing the app language"
+    },
     "languageSettingsSelectorLabel": "App language",
-    "@languageSettingsSelectorLabel": { "description": "Label above the language dropdown in settings" },
-
+    "@languageSettingsSelectorLabel": {
+        "description": "Label above the language dropdown in settings"
+    },
     "languageSettingsSystemOption": "System default ({language})",
     "@languageSettingsSystemOption": {
         "description": "Dropdown option that makes the app follow the phone/system language. The placeholder is the current phone language display name.",
         "placeholders": {
-            "language": { "type": "String", "example": "Deutsch" }
+            "language": {
+                "type": "String",
+                "example": "Deutsch"
+            }
         }
     },
-
     "languageSettingsSystemDescription": "Following your phone language: {language}.",
     "@languageSettingsSystemDescription": {
         "description": "Settings helper text when no manual app language override is selected. The placeholder is the current phone language display name.",
         "placeholders": {
-            "language": { "type": "String", "example": "Deutsch" }
+            "language": {
+                "type": "String",
+                "example": "Deutsch"
+            }
         }
     },
-
     "languageSettingsOverrideDescription": "Use this language instead of the phone language.",
-    "@languageSettingsOverrideDescription": { "description": "Settings helper text when a manual app language override is selected" },
-
+    "@languageSettingsOverrideDescription": {
+        "description": "Settings helper text when a manual app language override is selected"
+    },
     "darkModeLabel": "Dark mode",
-    "@darkModeLabel": { "description": "Label for the dark mode switch in settings" },
-
+    "@darkModeLabel": {
+        "description": "Label for the dark mode switch in settings"
+    },
     "darkModeSettingsDescription": "Use a darker interface.",
-    "@darkModeSettingsDescription": { "description": "Settings helper text for the dark mode switch" },
-
+    "@darkModeSettingsDescription": {
+        "description": "Settings helper text for the dark mode switch"
+    },
     "enableConfettiLabel": "Confetti",
-    "@enableConfettiLabel": { "description": "Label for the confetti preference switch" },
-
+    "@enableConfettiLabel": {
+        "description": "Label for the confetti preference switch"
+    },
     "enableConfettiSettingsDescription": "Show a celebration when you complete a bingo.",
-    "@enableConfettiSettingsDescription": { "description": "Settings helper text for the confetti preference switch" },
-
+    "@enableConfettiSettingsDescription": {
+        "description": "Settings helper text for the confetti preference switch"
+    },
     "preMadeTilesTitle": "Pre-made tiles",
-    "@preMadeTilesTitle": { "description": "Title of the pre-made tiles settings screen and menu entry" },
-
+    "@preMadeTilesTitle": {
+        "description": "Title of the pre-made tiles settings screen and menu entry"
+    },
     "preMadeTilesSettingsDescription": "Create reusable tile text for future boards.",
-    "@preMadeTilesSettingsDescription": { "description": "Settings entry helper text for pre-made tiles" },
-
+    "@preMadeTilesSettingsDescription": {
+        "description": "Settings entry helper text for pre-made tiles"
+    },
     "preMadeTilesDescription": "Create reusable bingo entries here. When you create a new board, you can add them without typing everything again.",
-    "@preMadeTilesDescription": { "description": "Description shown below the pre-made tiles screen title" },
-
+    "@preMadeTilesDescription": {
+        "description": "Description shown below the pre-made tiles screen title"
+    },
     "preMadeTilesSelectMode": "Select",
-    "@preMadeTilesSelectMode": { "description": "Segmented control label for selecting pre-made tiles" },
-
+    "@preMadeTilesSelectMode": {
+        "description": "Segmented control label for selecting pre-made tiles"
+    },
     "preMadeTilesEditMode": "Edit",
-    "@preMadeTilesEditMode": { "description": "Segmented control label for editing pre-made tiles" },
-
+    "@preMadeTilesEditMode": {
+        "description": "Segmented control label for editing pre-made tiles"
+    },
     "preMadeTileHint": "Tile text",
-    "@preMadeTileHint": { "description": "Placeholder for a pre-made tile text field" },
-
+    "@preMadeTileHint": {
+        "description": "Placeholder for a pre-made tile text field"
+    },
     "preMadeTilesAdd": "Add tile",
-    "@preMadeTilesAdd": { "description": "Accessible label and tooltip for adding a pre-made tile" },
-
+    "@preMadeTilesAdd": {
+        "description": "Accessible label and tooltip for adding a pre-made tile"
+    },
     "preMadeTilesDelete": "Delete tile",
-    "@preMadeTilesDelete": { "description": "Accessible label and tooltip for deleting a pre-made tile" },
-
+    "@preMadeTilesDelete": {
+        "description": "Accessible label and tooltip for deleting a pre-made tile"
+    },
     "preMadeTilesSelectAll": "Un/select all",
-    "@preMadeTilesSelectAll": { "description": "Checkbox label for toggling all pre-made tile selections" },
-
+    "@preMadeTilesSelectAll": {
+        "description": "Checkbox label for toggling all pre-made tile selections"
+    },
     "preMadeTilesSelectNone": "Select none",
-    "@preMadeTilesSelectNone": { "description": "Button label for clearing all selected pre-made tiles" },
-
+    "@preMadeTilesSelectNone": {
+        "description": "Button label for clearing all selected pre-made tiles"
+    },
     "preMadeTilesApply": "Apply",
-    "@preMadeTilesApply": { "description": "Button label for applying selected pre-made tiles to a board" },
-
+    "@preMadeTilesApply": {
+        "description": "Button label for applying selected pre-made tiles to a board"
+    },
     "preMadeTilesReplaceItems": "Replace items",
-    "@preMadeTilesReplaceItems": { "description": "Button label for replacing current board items with selected pre-made items" },
-
+    "@preMadeTilesReplaceItems": {
+        "description": "Button label for replacing current board items with selected pre-made items"
+    },
     "preMadeTilesFillItems": "Fill items",
-    "@preMadeTilesFillItems": { "description": "Button label for filling empty board items with selected pre-made items" },
-
+    "@preMadeTilesFillItems": {
+        "description": "Button label for filling empty board items with selected pre-made items"
+    },
     "preMadeTilesBoardActionHelp": "Replace swaps the board entries with a random draw from your selection. Fill only adds items to empty tiles. On odd boards, the center tile stays in place.",
-    "@preMadeTilesBoardActionHelp": { "description": "Helper text explaining replace and fill actions for pre-made items on an existing board" },
-
+    "@preMadeTilesBoardActionHelp": {
+        "description": "Helper text explaining replace and fill actions for pre-made items on an existing board"
+    },
     "preMadeTilesSelectedCount": "{selected} / {total} selected",
     "@preMadeTilesSelectedCount": {
         "description": "Count of selected pre-made tiles",
         "placeholders": {
-            "selected": { "type": "int", "example": "12" },
-            "total": { "type": "int", "example": "24" }
+            "selected": {
+                "type": "int",
+                "example": "12"
+            },
+            "total": {
+                "type": "int",
+                "example": "24"
+            }
         }
     },
-
     "preMadeTilesEmptyTitle": "No tiles yet",
-    "@preMadeTilesEmptyTitle": { "description": "Empty-state title for the pre-made tiles screen" },
-
+    "@preMadeTilesEmptyTitle": {
+        "description": "Empty-state title for the pre-made tiles screen"
+    },
     "preMadeTilesEmptyBody": "Add a tile to start building a reusable list.",
-    "@preMadeTilesEmptyBody": { "description": "Empty-state helper text for the pre-made tiles screen" },
-
+    "@preMadeTilesEmptyBody": {
+        "description": "Empty-state helper text for the pre-made tiles screen"
+    },
     "proposeFeatures": "Propose Features",
-    "@proposeFeatures": { "description": "Menu item that opens the UserOrient feedback board" },
-
+    "@proposeFeatures": {
+        "description": "Menu item that opens the UserOrient feedback board"
+    },
     "proposeFeaturesSettingsDescription": "Vote on ideas and suggest what to build next.",
-    "@proposeFeaturesSettingsDescription": { "description": "Settings helper text for the feature request entry" },
-
+    "@proposeFeaturesSettingsDescription": {
+        "description": "Settings helper text for the feature request entry"
+    },
     "supportMeDirectly": "Support the developer",
-    "@supportMeDirectly": { "description": "Menu item that opens the direct-support paywall" },
-
+    "@supportMeDirectly": {
+        "description": "Menu item that opens the direct-support paywall"
+    },
     "supportMeDirectlySettingsDescription": "Help fund development and keep the app improving.",
-    "@supportMeDirectlySettingsDescription": { "description": "Settings helper text for the direct support entry" },
-
+    "@supportMeDirectlySettingsDescription": {
+        "description": "Settings helper text for the direct support entry"
+    },
     "supportCarouselProTitle": "Support Custom Bingo",
-    "@supportCarouselProTitle": { "description": "Title of the home-screen support carousel item that opens the paywall" },
-
+    "@supportCarouselProTitle": {
+        "description": "Title of the home-screen support carousel item that opens the paywall"
+    },
     "supportCarouselProSubtitle": "Unlock bonus colors and help keep the app independent.",
-    "@supportCarouselProSubtitle": { "description": "Subtitle of the home-screen support carousel item that opens the paywall" },
-
+    "@supportCarouselProSubtitle": {
+        "description": "Subtitle of the home-screen support carousel item that opens the paywall"
+    },
     "supportCarouselRateTitle": "Enjoying the app?",
-    "@supportCarouselRateTitle": { "description": "Title of the home-screen support carousel item that asks for a store review" },
-
+    "@supportCarouselRateTitle": {
+        "description": "Title of the home-screen support carousel item that asks for a store review"
+    },
     "supportCarouselRateSubtitle": "A quick review helps more people find Custom Bingo.",
-    "@supportCarouselRateSubtitle": { "description": "Subtitle of the home-screen support carousel item that asks for a store review" },
-
+    "@supportCarouselRateSubtitle": {
+        "description": "Subtitle of the home-screen support carousel item that asks for a store review"
+    },
     "rateTheApp": "Rate the app",
-    "@rateTheApp": { "description": "Settings entry that opens the native store rating dialog" },
-
+    "@rateTheApp": {
+        "description": "Settings entry that opens the native store rating dialog"
+    },
     "rateTheAppSettingsDescription": "Open the store rating prompt.",
-    "@rateTheAppSettingsDescription": { "description": "Settings helper text for the app rating entry" },
-
+    "@rateTheAppSettingsDescription": {
+        "description": "Settings helper text for the app rating entry"
+    },
     "contactMe": "Contact me",
-    "@contactMe": { "description": "Settings entry that opens an email composer" },
-
+    "@contactMe": {
+        "description": "Settings entry that opens an email composer"
+    },
     "contactMeSettingsDescription": "Send feedback, questions, or bug reports by email.",
-    "@contactMeSettingsDescription": { "description": "Settings helper text for the contact email entry" },
-
+    "@contactMeSettingsDescription": {
+        "description": "Settings helper text for the contact email entry"
+    },
     "paywallTitle": "Support Custom Bingo",
-    "@paywallTitle": { "description": "AppBar title of the direct-support paywall" },
-
+    "@paywallTitle": {
+        "description": "AppBar title of the direct-support paywall"
+    },
     "paywallThankYouTitle": "Thank you",
-    "@paywallThankYouTitle": { "description": "Paywall title shown after Pro access is active" },
-
+    "@paywallThankYouTitle": {
+        "description": "Paywall title shown after Pro access is active"
+    },
     "paywallSupportTitle": "Support Custom Bingo",
-    "@paywallSupportTitle": { "description": "Main title on the direct-support paywall" },
-
+    "@paywallSupportTitle": {
+        "description": "Main title on the direct-support paywall"
+    },
     "paywallSupportBody": "This purchase supports me, the developer, directly. You get my gratitude and a few small bonus things for your boards.",
-    "@paywallSupportBody": { "description": "Main body copy on the direct-support paywall" },
-
+    "@paywallSupportBody": {
+        "description": "Main body copy on the direct-support paywall"
+    },
     "paywallBonusGratitude": "My gratitude, sincerely.",
-    "@paywallBonusGratitude": { "description": "First benefit line on the direct-support paywall" },
-
+    "@paywallBonusGratitude": {
+        "description": "First benefit line on the direct-support paywall"
+    },
     "paywallBonusColors": "A few extra board colors.",
-    "@paywallBonusColors": { "description": "Second benefit line on the direct-support paywall" },
-
+    "@paywallBonusColors": {
+        "description": "Second benefit line on the direct-support paywall"
+    },
     "paywallBonusExtras": "Small supporter extras over time.",
-    "@paywallBonusExtras": { "description": "Third benefit line on the direct-support paywall" },
-
+    "@paywallBonusExtras": {
+        "description": "Third benefit line on the direct-support paywall"
+    },
     "paywallFreeForever": "No one ever needs to pay for this app. Custom Bingo stays usable for everyone.",
-    "@paywallFreeForever": { "description": "Footer reassurance on the direct-support paywall" },
-
+    "@paywallFreeForever": {
+        "description": "Footer reassurance on the direct-support paywall"
+    },
     "paywallLoadingPrice": "Loading price",
-    "@paywallLoadingPrice": { "description": "Placeholder shown while the paywall price is loading" },
-
+    "@paywallLoadingPrice": {
+        "description": "Placeholder shown while the paywall price is loading"
+    },
     "paywallUnavailable": "Unavailable",
-    "@paywallUnavailable": { "description": "Paywall price/button text when purchases are unavailable" },
-
+    "@paywallUnavailable": {
+        "description": "Paywall price/button text when purchases are unavailable"
+    },
     "paywallSupportOnce": "Support once",
-    "@paywallSupportOnce": { "description": "Purchase button label on the direct-support paywall" },
-
+    "@paywallSupportOnce": {
+        "description": "Purchase button label on the direct-support paywall"
+    },
     "paywallRestorePurchase": "Restore purchase",
-    "@paywallRestorePurchase": { "description": "Restore button label on the direct-support paywall" },
-
+    "@paywallRestorePurchase": {
+        "description": "Restore button label on the direct-support paywall"
+    },
     "paywallProActiveToast": "Custom Bingo Pro is active.",
-    "@paywallProActiveToast": { "description": "Toast shown after a successful Pro purchase" },
-
+    "@paywallProActiveToast": {
+        "description": "Toast shown after a successful Pro purchase"
+    },
     "paywallPurchaseInactiveToast": "Purchase finished, but Pro is not active.",
-    "@paywallPurchaseInactiveToast": { "description": "Toast shown if a purchase returns without Pro access" },
-
+    "@paywallPurchaseInactiveToast": {
+        "description": "Toast shown if a purchase returns without Pro access"
+    },
     "paywallProRestoredToast": "Custom Bingo Pro restored.",
-    "@paywallProRestoredToast": { "description": "Toast shown after restoring Pro access" },
-
+    "@paywallProRestoredToast": {
+        "description": "Toast shown after restoring Pro access"
+    },
     "paywallNoPurchaseFoundToast": "No Pro purchase found.",
-    "@paywallNoPurchaseFoundToast": { "description": "Toast shown when restore finds no Pro access" },
-
+    "@paywallNoPurchaseFoundToast": {
+        "description": "Toast shown when restore finds no Pro access"
+    },
     "paywallPurchasesUnavailable": "Purchases are unavailable right now.",
-    "@paywallPurchasesUnavailable": { "description": "Fallback error text for a paywall purchase error" },
-
+    "@paywallPurchasesUnavailable": {
+        "description": "Fallback error text for a paywall purchase error"
+    },
     "paywallPlatformUnavailable": "Purchases are unavailable on this platform.",
-    "@paywallPlatformUnavailable": { "description": "Fallback paywall text when purchases are not configured for the platform" },
-
+    "@paywallPlatformUnavailable": {
+        "description": "Fallback paywall text when purchases are not configured for the platform"
+    },
     "paywallCouldNotLoad": "Could not load purchase information.",
-    "@paywallCouldNotLoad": { "description": "Fallback paywall error text for an unknown purchase loading error" },
-
+    "@paywallCouldNotLoad": {
+        "description": "Fallback paywall error text for an unknown purchase loading error"
+    },
     "shareTitle": "Share the bingo card",
-    "@shareTitle": { "description": "Title of the share dialog" },
-
+    "@shareTitle": {
+        "description": "Title of the share dialog"
+    },
     "shareDialogPrompt": "How would you like to share?",
-    "@shareDialogPrompt": { "description": "Section header above the two share options" },
-
+    "@shareDialogPrompt": {
+        "description": "Section header above the two share options"
+    },
     "shareImageOptionTitle": "Share as image",
-    "@shareImageOptionTitle": { "description": "Title of the image-share option in the share dialog" },
-
+    "@shareImageOptionTitle": {
+        "description": "Title of the image-share option in the share dialog"
+    },
     "shareImageOptionHelper": "Send a picture of your card. Anyone can see it — even without the app.",
-    "@shareImageOptionHelper": { "description": "Helper text explaining what 'Share as image' does" },
-
+    "@shareImageOptionHelper": {
+        "description": "Helper text explaining what 'Share as image' does"
+    },
     "shareImageOptionButton": "Share image",
-    "@shareImageOptionButton": { "description": "Confirm button on the image-share option" },
-
+    "@shareImageOptionButton": {
+        "description": "Confirm button on the image-share option"
+    },
     "shareInviteOptionTitle": "Invite friends to play",
-    "@shareInviteOptionTitle": { "description": "Title of the play-together invite option" },
-
+    "@shareInviteOptionTitle": {
+        "description": "Title of the play-together invite option"
+    },
     "shareInviteOptionHelper": "Send this link to your friends who also have this app installed. They get the same card and you can play together.",
-    "@shareInviteOptionHelper": { "description": "Helper text explaining what the invite link does" },
-
+    "@shareInviteOptionHelper": {
+        "description": "Helper text explaining what the invite link does"
+    },
     "shareInviteIncludeMarks": "Include my checkmarks",
-    "@shareInviteIncludeMarks": { "description": "Toggle label: include the sender's marks in the invite" },
-
+    "@shareInviteIncludeMarks": {
+        "description": "Toggle label: include the sender's marks in the invite"
+    },
     "shareInviteIncludeMarksHelper": "When on, your friends will see what you've already crossed off.",
-    "@shareInviteIncludeMarksHelper": { "description": "Helper text under the include-checkmarks toggle" },
-
+    "@shareInviteIncludeMarksHelper": {
+        "description": "Helper text under the include-checkmarks toggle"
+    },
     "shareInviteOptionButton": "Send invite",
-    "@shareInviteOptionButton": { "description": "Confirm button on the invite-link option" },
-
+    "@shareInviteOptionButton": {
+        "description": "Confirm button on the invite-link option"
+    },
     "shareInviteText": "Play \"{name}\" with me! Open it in the app:\n{link}",
     "@shareInviteText": {
         "description": "Body text passed to the system share sheet alongside the invite link",
         "placeholders": {
-            "name": { "type": "String", "example": "Dateline BINGO" },
-            "link": { "type": "String", "example": "https://bingogrid.web.app/import?d=…" }
+            "name": {
+                "type": "String",
+                "example": "Dateline BINGO"
+            },
+            "link": {
+                "type": "String",
+                "example": "https://bingogrid.web.app/import?d=…"
+            }
         }
     },
-
     "close": "Close",
-    "@close": { "description": "Generic close button" },
-
+    "@close": {
+        "description": "Generic close button"
+    },
     "shareSubject": "Bingo Card",
-    "@shareSubject": { "description": "Subject/title used by the system share sheet" },
-
+    "@shareSubject": {
+        "description": "Subject/title used by the system share sheet"
+    },
     "importTitle": "A friend shared a bingo card with you",
-    "@importTitle": { "description": "Title of the import-card screen shown to the receiver" },
-
+    "@importTitle": {
+        "description": "Title of the import-card screen shown to the receiver"
+    },
     "importBody": "Add it to your cards so you can play along?",
-    "@importBody": { "description": "Body of the import-card screen" },
-
+    "@importBody": {
+        "description": "Body of the import-card screen"
+    },
     "importConfirm": "Add to my cards",
-    "@importConfirm": { "description": "Confirm button on the import-card screen" },
-
+    "@importConfirm": {
+        "description": "Confirm button on the import-card screen"
+    },
     "importCancel": "Not now",
-    "@importCancel": { "description": "Cancel button on the import-card screen" },
-
+    "@importCancel": {
+        "description": "Cancel button on the import-card screen"
+    },
     "importCollisionToast": "You already had a card with this name, so I added it as \"{newName}\".",
     "@importCollisionToast": {
         "description": "Toast shown after silently renaming an imported card to avoid a collision",
         "placeholders": {
-            "newName": { "type": "String", "example": "Dateline BINGO (2)" }
+            "newName": {
+                "type": "String",
+                "example": "Dateline BINGO (2)"
+            }
         }
     },
-
     "importBadLinkToast": "Sorry, this invite couldn't be opened. Ask your friend to send it again.",
-    "@importBadLinkToast": { "description": "Toast shown when an invite link is malformed" },
-
+    "@importBadLinkToast": {
+        "description": "Toast shown when an invite link is malformed"
+    },
     "importOutdatedAppToast": "Update the app to open this invite.",
-    "@importOutdatedAppToast": { "description": "Toast shown when an invite payload uses a newer schema" },
-
+    "@importOutdatedAppToast": {
+        "description": "Toast shown when an invite payload uses a newer schema"
+    },
     "toastInfo": "Info",
-    "@toastInfo": { "description": "Title of an informational toast" },
-
+    "@toastInfo": {
+        "description": "Title of an informational toast"
+    },
     "toastSuccess": "Success",
-    "@toastSuccess": { "description": "Title of a success toast" },
-
+    "@toastSuccess": {
+        "description": "Title of a success toast"
+    },
     "toastError": "Error",
-    "@toastError": { "description": "Title of an error toast" },
-
+    "@toastError": {
+        "description": "Title of an error toast"
+    },
     "lastChangeNever": "Last change: Never",
-    "@lastChangeNever": { "description": "Footer line shown when a card has never been edited" },
-
+    "@lastChangeNever": {
+        "description": "Footer line shown when a card has never been edited"
+    },
     "lastChange": "Last change: {date} {time}",
     "@lastChange": {
         "description": "Footer line showing when the card was last edited",
         "placeholders": {
-            "date": { "type": "String", "example": "5.5.2026" },
-            "time": { "type": "String", "example": "14:30" }
+            "date": {
+                "type": "String",
+                "example": "5.5.2026"
+            },
+            "time": {
+                "type": "String",
+                "example": "14:30"
+            }
         }
     },
-
     "screenshotCaptionPlaying": "Just a simple app to create bingo board.\n\nNo signup, no ads, fully free to use.",
-    "@screenshotCaptionPlaying": { "description": "Promotional caption for the screenshot showing a played bingo board" },
+    "@screenshotCaptionPlaying": {
+        "description": "Promotional caption for the screenshot showing a played bingo board"
+    },
     "screenshotCaptionCreate": "Literally just 2 screens to create a bingo grid.",
-    "@screenshotCaptionCreate": { "description": "Promotional caption for the screenshot showing the new-board screen" },
+    "@screenshotCaptionCreate": {
+        "description": "Promotional caption for the screenshot showing the new-board screen"
+    },
     "screenshotCaptionLocked": "That's it.",
-    "@screenshotCaptionLocked": { "description": "Promotional caption for the screenshot showing the locked board" },
+    "@screenshotCaptionLocked": {
+        "description": "Promotional caption for the screenshot showing the locked board"
+    },
     "screenshotBoardName": "David's Wedding",
-    "@screenshotBoardName": { "description": "Sample bingo board name used in generated screenshots" },
+    "@screenshotBoardName": {
+        "description": "Sample bingo board name used in generated screenshots"
+    },
     "screenshotTilePhoneDuringVows": "Phone during vows",
-    "@screenshotTilePhoneDuringVows": { "description": "Sample bingo tile text used in generated screenshots" },
+    "@screenshotTilePhoneDuringVows": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
     "screenshotTileChampagneSpilled": "Champagne spilled",
-    "@screenshotTileChampagneSpilled": { "description": "Sample bingo tile text used in generated screenshots" },
+    "@screenshotTileChampagneSpilled": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
     "screenshotTileSpeechTears": "Speech tears",
-    "@screenshotTileSpeechTears": { "description": "Sample bingo tile text used in generated screenshots" },
+    "@screenshotTileSpeechTears": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
     "screenshotTileDramaticEntrance": "Dramatic entrance",
-    "@screenshotTileDramaticEntrance": { "description": "Sample bingo tile text used in generated screenshots" },
+    "@screenshotTileDramaticEntrance": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
     "screenshotTileKidsDanceFloor": "Kids take the dance floor",
-    "@screenshotTileKidsDanceFloor": { "description": "Sample bingo tile text used in generated screenshots" },
+    "@screenshotTileKidsDanceFloor": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
     "screenshotTileGuestToast": "Guest gives a toast",
-    "@screenshotTileGuestToast": { "description": "Sample bingo tile text used in generated screenshots" },
+    "@screenshotTileGuestToast": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
     "screenshotTileCrowdClapsEarly": "Crowd claps early",
-    "@screenshotTileCrowdClapsEarly": { "description": "Sample bingo tile text used in generated screenshots" },
+    "@screenshotTileCrowdClapsEarly": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
     "screenshotTileDjClassic": "DJ plays a classic",
-    "@screenshotTileDjClassic": { "description": "Sample bingo tile text used in generated screenshots" },
+    "@screenshotTileDjClassic": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
     "screenshotTileGroupPhotoChaos": "Group photo chaos",
-    "@screenshotTileGroupPhotoChaos": { "description": "Sample bingo tile text used in generated screenshots" }
+    "@screenshotTileGroupPhotoChaos": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    }
 }

--- a/lib/l10n/arb/app_en.arb
+++ b/lib/l10n/arb/app_en.arb
@@ -155,6 +155,31 @@
     "themeColorSettingsDescription": "Choose the palette used across the app.",
     "@themeColorSettingsDescription": { "description": "Settings helper text for the theme color selector" },
 
+    "languageSettingsTitle": "Language",
+    "@languageSettingsTitle": { "description": "Settings tile title for choosing the app language" },
+
+    "languageSettingsSelectorLabel": "App language",
+    "@languageSettingsSelectorLabel": { "description": "Label above the language dropdown in settings" },
+
+    "languageSettingsSystemOption": "System default ({language})",
+    "@languageSettingsSystemOption": {
+        "description": "Dropdown option that makes the app follow the phone/system language. The placeholder is the current phone language display name.",
+        "placeholders": {
+            "language": { "type": "String", "example": "Deutsch" }
+        }
+    },
+
+    "languageSettingsSystemDescription": "Following your phone language: {language}.",
+    "@languageSettingsSystemDescription": {
+        "description": "Settings helper text when no manual app language override is selected. The placeholder is the current phone language display name.",
+        "placeholders": {
+            "language": { "type": "String", "example": "Deutsch" }
+        }
+    },
+
+    "languageSettingsOverrideDescription": "Use this language instead of the phone language.",
+    "@languageSettingsOverrideDescription": { "description": "Settings helper text when a manual app language override is selected" },
+
     "darkModeLabel": "Dark mode",
     "@darkModeLabel": { "description": "Label for the dark mode switch in settings" },
 

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -24,23 +24,23 @@
     "@updateCardButton": {
         "description": "Confirm button on the edit-card screen"
     },
-    "newBoardPreMadeSectionTitle": "Your pre-made items",
+    "newBoardPreMadeSectionTitle": "Tus elementos preparados",
     "@newBoardPreMadeSectionTitle": {
         "description": "Expandable section title for pre-made items on the new-board screen"
     },
-    "newBoardPreMadeButton": "Start with pre-made items",
+    "newBoardPreMadeButton": "Empezar con elementos preparados",
     "@newBoardPreMadeButton": {
         "description": "Button that opens pre-made item selection from the new-board screen"
     },
-    "newBoardPreMadeChangeButton": "Change pre-made items",
+    "newBoardPreMadeChangeButton": "Cambiar elementos preparados",
     "@newBoardPreMadeChangeButton": {
         "description": "Button that reopens pre-made item selection after items have been applied"
     },
-    "newBoardPreMadeClearButton": "Clear pre-made items",
+    "newBoardPreMadeClearButton": "Borrar elementos preparados",
     "@newBoardPreMadeClearButton": {
         "description": "Button that clears applied pre-made entries from the new-board form"
     },
-    "newBoardPreMadeAppliedCount": "{count} pre-made entries applied",
+    "newBoardPreMadeAppliedCount": "{count} entradas preparadas aplicadas",
     "@newBoardPreMadeAppliedCount": {
         "description": "Summary of how many pre-made entries are applied to the new-board form",
         "placeholders": {
@@ -50,7 +50,7 @@
             }
         }
     },
-    "newBoardPreMadeFullSummary": "{used} will be drawn at random for this board.",
+    "newBoardPreMadeFullSummary": "Se elegirán {used} al azar para este tablero.",
     "@newBoardPreMadeFullSummary": {
         "description": "Summary when applied pre-made entries can fill the new board",
         "placeholders": {
@@ -60,7 +60,7 @@
             }
         }
     },
-    "newBoardPreMadePartialSummary": "{used} cells will be filled. {blank} will stay blank.",
+    "newBoardPreMadePartialSummary": "Se rellenarán {used} casillas. {blank} quedarán vacías.",
     "@newBoardPreMadePartialSummary": {
         "description": "Summary when applied pre-made entries are fewer than the board cells",
         "placeholders": {
@@ -82,19 +82,19 @@
     "@toggleHint": {
         "description": "Hint banner above the bingo grid"
     },
-    "editingHintBefore": "Press the lock icon",
+    "editingHintBefore": "Pulsa el icono de candado",
     "@editingHintBefore": {
         "description": "First half of the hint that explains the lock toggle. The lock icon is rendered between the two halves."
     },
-    "editingHintAfter": " to make the fields not editable anymore.",
+    "editingHintAfter": " para que las casillas dejen de ser editables.",
     "@editingHintAfter": {
         "description": "Second half of the lock-toggle hint, rendered after the lock icon."
     },
-    "deleteCardTitle": "Delete Card",
+    "deleteCardTitle": "Eliminar tarjeta",
     "@deleteCardTitle": {
         "description": "Title of the delete-card confirmation dialog"
     },
-    "deleteCardConfirm": "Are you sure you want to delete this card?",
+    "deleteCardConfirm": "¿Seguro que quieres eliminar esta tarjeta?",
     "@deleteCardConfirm": {
         "description": "Body of the delete-card confirmation dialog"
     },
@@ -106,11 +106,11 @@
     "@delete": {
         "description": "Generic delete button"
     },
-    "shuffleCardTitle": "Shuffle Card",
+    "shuffleCardTitle": "Mezclar tarjeta",
     "@shuffleCardTitle": {
         "description": "Title of the shuffle confirmation dialog"
     },
-    "shuffleCardConfirm": "Are you sure you want to shuffle this card? All fields will be unchecked, after shuffling.",
+    "shuffleCardConfirm": "¿Seguro que quieres mezclar esta tarjeta? Todas las casillas quedarán desmarcadas después.",
     "@shuffleCardConfirm": {
         "description": "Body of the shuffle confirmation dialog"
     },
@@ -118,19 +118,19 @@
     "@shuffle": {
         "description": "Confirm button to shuffle the card"
     },
-    "ratingPromptTitle": "Do you like Custom Bingo?",
+    "ratingPromptTitle": "¿Te gusta Custom Bingo?",
     "@ratingPromptTitle": {
         "description": "Title of the dialog shown before asking for an app store review"
     },
-    "ratingPromptBody": "If so, a quick store review helps others find it.",
+    "ratingPromptBody": "Si es así, una reseña rápida en la tienda ayuda a que más personas la encuentren.",
     "@ratingPromptBody": {
         "description": "Body of the dialog shown before asking for an app store review"
     },
-    "ratingPromptNo": "Not really",
+    "ratingPromptNo": "No mucho",
     "@ratingPromptNo": {
         "description": "Dismiss button for the rating prompt dialog"
     },
-    "ratingPromptYes": "Yes, I like it",
+    "ratingPromptYes": "Sí, me gusta",
     "@ratingPromptYes": {
         "description": "Confirm button that continues to the native app store review flow"
     },
@@ -142,7 +142,7 @@
     "@boardActionEditBoard": {
         "description": "Menu item that opens the board edit flow from the board action bar"
     },
-    "boardActionAddPreMadeItems": "Add pre-made items",
+    "boardActionAddPreMadeItems": "Añadir elementos preparados",
     "@boardActionAddPreMadeItems": {
         "description": "Debug menu item placeholder for filling a board with pre-made items"
     },
@@ -154,11 +154,11 @@
     "@edit": {
         "description": "Edit menu item in a cell's context menu"
     },
-    "markDone": "Mark Done",
+    "markDone": "Marcar como hecho",
     "@markDone": {
         "description": "Cell context menu item: mark this cell as done"
     },
-    "markNotDone": "Mark Not Done",
+    "markNotDone": "Marcar como no hecho",
     "@markNotDone": {
         "description": "Cell context menu item: clear the done state"
     },
@@ -166,15 +166,53 @@
     "@newCardMenuItem": {
         "description": "Menu item that opens the new-card screen"
     },
+    "allBoardsMenuItem": "Todos los tableros",
+    "@allBoardsMenuItem": {
+        "description": "Menu item that opens the list of all saved boards"
+    },
     "yourCardsHeader": "Tus tableros",
     "@yourCardsHeader": {
         "description": "Section header in the popup menu listing saved cards"
+    },
+    "noBoardsYet": "Aún no hay tableros",
+    "@noBoardsYet": {
+        "description": "Empty-state title shown when there are no saved boards"
+    },
+    "pageNotFoundTitle": "Página no encontrada",
+    "@pageNotFoundTitle": {
+        "description": "Title shown on the fallback route when a page cannot be found"
+    },
+    "homeButton": "Inicio",
+    "@homeButton": {
+        "description": "Button that navigates back to the home screen"
+    },
+    "revenueCatUserIdLabel": "ID de usuario de RevenueCat: {userId}",
+    "@revenueCatUserIdLabel": {
+        "description": "Debug settings label showing the RevenueCat user id",
+        "placeholders": {
+            "userId": {
+                "type": "String",
+                "example": "abc123"
+            }
+        }
+    },
+    "copyRevenueCatUserIdTooltip": "Copiar ID de usuario de RevenueCat",
+    "@copyRevenueCatUserIdTooltip": {
+        "description": "Tooltip for copying the RevenueCat user id from debug settings"
+    },
+    "revenueCatUserIdCopiedToast": "ID de usuario de RevenueCat copiado.",
+    "@revenueCatUserIdCopiedToast": {
+        "description": "Toast shown after copying the RevenueCat user id"
     },
     "settingsHeader": "Ajustes",
     "@settingsHeader": {
         "description": "Section header in the popup menu"
     },
-    "appearanceMenuItem": "Appearance",
+    "clearSettingsMenuItem": "Borrar ajustes",
+    "@clearSettingsMenuItem": {
+        "description": "Debug menu item that clears saved settings"
+    },
+    "appearanceMenuItem": "Apariencia",
     "@appearanceMenuItem": {
         "description": "Menu item that opens the appearance settings screen"
     },
@@ -254,63 +292,63 @@
     "@enableConfettiSettingsDescription": {
         "description": "Settings helper text for the confetti preference switch"
     },
-    "preMadeTilesTitle": "Pre-made tiles",
+    "preMadeTilesTitle": "Casillas preparadas",
     "@preMadeTilesTitle": {
         "description": "Title of the pre-made tiles settings screen and menu entry"
     },
-    "preMadeTilesSettingsDescription": "Create reusable tile text for future boards.",
+    "preMadeTilesSettingsDescription": "Crea textos de casilla reutilizables para futuros tableros.",
     "@preMadeTilesSettingsDescription": {
         "description": "Settings entry helper text for pre-made tiles"
     },
-    "preMadeTilesDescription": "Create reusable bingo entries here. When you create a new board, you can add them without typing everything again.",
+    "preMadeTilesDescription": "Crea aquí entradas de bingo reutilizables. Cuando crees un tablero nuevo, podrás añadirlas sin volver a escribirlo todo.",
     "@preMadeTilesDescription": {
         "description": "Description shown below the pre-made tiles screen title"
     },
-    "preMadeTilesSelectMode": "Select",
+    "preMadeTilesSelectMode": "Seleccionar",
     "@preMadeTilesSelectMode": {
         "description": "Segmented control label for selecting pre-made tiles"
     },
-    "preMadeTilesEditMode": "Edit",
+    "preMadeTilesEditMode": "Editar",
     "@preMadeTilesEditMode": {
         "description": "Segmented control label for editing pre-made tiles"
     },
-    "preMadeTileHint": "Tile text",
+    "preMadeTileHint": "Texto de la casilla",
     "@preMadeTileHint": {
         "description": "Placeholder for a pre-made tile text field"
     },
-    "preMadeTilesAdd": "Add tile",
+    "preMadeTilesAdd": "Añadir casilla",
     "@preMadeTilesAdd": {
         "description": "Accessible label and tooltip for adding a pre-made tile"
     },
-    "preMadeTilesDelete": "Delete tile",
+    "preMadeTilesDelete": "Eliminar casilla",
     "@preMadeTilesDelete": {
         "description": "Accessible label and tooltip for deleting a pre-made tile"
     },
-    "preMadeTilesSelectAll": "Un/select all",
+    "preMadeTilesSelectAll": "Seleccionar/deseleccionar todo",
     "@preMadeTilesSelectAll": {
         "description": "Checkbox label for toggling all pre-made tile selections"
     },
-    "preMadeTilesSelectNone": "Select none",
+    "preMadeTilesSelectNone": "No seleccionar nada",
     "@preMadeTilesSelectNone": {
         "description": "Button label for clearing all selected pre-made tiles"
     },
-    "preMadeTilesApply": "Apply",
+    "preMadeTilesApply": "Aplicar",
     "@preMadeTilesApply": {
         "description": "Button label for applying selected pre-made tiles to a board"
     },
-    "preMadeTilesReplaceItems": "Replace items",
+    "preMadeTilesReplaceItems": "Reemplazar elementos",
     "@preMadeTilesReplaceItems": {
         "description": "Button label for replacing current board items with selected pre-made items"
     },
-    "preMadeTilesFillItems": "Fill items",
+    "preMadeTilesFillItems": "Rellenar elementos",
     "@preMadeTilesFillItems": {
         "description": "Button label for filling empty board items with selected pre-made items"
     },
-    "preMadeTilesBoardActionHelp": "Replace swaps the board entries with a random draw from your selection. Fill only adds items to empty tiles. On odd boards, the center tile stays in place.",
+    "preMadeTilesBoardActionHelp": "Reemplazar cambia las entradas del tablero por una selección aleatoria. Rellenar solo añade elementos a casillas vacías. En tableros impares, la casilla central se mantiene.",
     "@preMadeTilesBoardActionHelp": {
         "description": "Helper text explaining replace and fill actions for pre-made items on an existing board"
     },
-    "preMadeTilesSelectedCount": "{selected} / {total} selected",
+    "preMadeTilesSelectedCount": "{selected} / {total} seleccionadas",
     "@preMadeTilesSelectedCount": {
         "description": "Count of selected pre-made tiles",
         "placeholders": {
@@ -324,135 +362,135 @@
             }
         }
     },
-    "preMadeTilesEmptyTitle": "No tiles yet",
+    "preMadeTilesEmptyTitle": "Aún no hay casillas",
     "@preMadeTilesEmptyTitle": {
         "description": "Empty-state title for the pre-made tiles screen"
     },
-    "preMadeTilesEmptyBody": "Add a tile to start building a reusable list.",
+    "preMadeTilesEmptyBody": "Añade una casilla para empezar una lista reutilizable.",
     "@preMadeTilesEmptyBody": {
         "description": "Empty-state helper text for the pre-made tiles screen"
     },
-    "proposeFeatures": "Propose Features",
+    "proposeFeatures": "Proponer funciones",
     "@proposeFeatures": {
         "description": "Menu item that opens the UserOrient feedback board"
     },
-    "proposeFeaturesSettingsDescription": "Vote on ideas and suggest what to build next.",
+    "proposeFeaturesSettingsDescription": "Vota ideas y sugiere qué crear después.",
     "@proposeFeaturesSettingsDescription": {
         "description": "Settings helper text for the feature request entry"
     },
-    "supportMeDirectly": "Support the developer",
+    "supportMeDirectly": "Apoyar al desarrollador",
     "@supportMeDirectly": {
         "description": "Menu item that opens the direct-support paywall"
     },
-    "supportMeDirectlySettingsDescription": "Help fund development and keep the app improving.",
+    "supportMeDirectlySettingsDescription": "Ayuda a financiar el desarrollo y a seguir mejorando la app.",
     "@supportMeDirectlySettingsDescription": {
         "description": "Settings helper text for the direct support entry"
     },
-    "supportCarouselProTitle": "Support Custom Bingo",
+    "supportCarouselProTitle": "Apoya Custom Bingo",
     "@supportCarouselProTitle": {
         "description": "Title of the home-screen support carousel item that opens the paywall"
     },
-    "supportCarouselProSubtitle": "Unlock bonus colors and help keep the app independent.",
+    "supportCarouselProSubtitle": "Desbloquea colores extra y ayuda a mantener la app independiente.",
     "@supportCarouselProSubtitle": {
         "description": "Subtitle of the home-screen support carousel item that opens the paywall"
     },
-    "supportCarouselRateTitle": "Enjoying the app?",
+    "supportCarouselRateTitle": "¿Disfrutas la app?",
     "@supportCarouselRateTitle": {
         "description": "Title of the home-screen support carousel item that asks for a store review"
     },
-    "supportCarouselRateSubtitle": "A quick review helps more people find Custom Bingo.",
+    "supportCarouselRateSubtitle": "Una reseña rápida ayuda a que más personas encuentren Custom Bingo.",
     "@supportCarouselRateSubtitle": {
         "description": "Subtitle of the home-screen support carousel item that asks for a store review"
     },
-    "rateTheApp": "Rate the app",
+    "rateTheApp": "Valorar la app",
     "@rateTheApp": {
         "description": "Settings entry that opens the native store rating dialog"
     },
-    "rateTheAppSettingsDescription": "Open the store rating prompt.",
+    "rateTheAppSettingsDescription": "Abrir la solicitud de valoración de la tienda.",
     "@rateTheAppSettingsDescription": {
         "description": "Settings helper text for the app rating entry"
     },
-    "contactMe": "Contact me",
+    "contactMe": "Contactarme",
     "@contactMe": {
         "description": "Settings entry that opens an email composer"
     },
-    "contactMeSettingsDescription": "Send feedback, questions, or bug reports by email.",
+    "contactMeSettingsDescription": "Envía comentarios, preguntas o informes de errores por email.",
     "@contactMeSettingsDescription": {
         "description": "Settings helper text for the contact email entry"
     },
-    "paywallTitle": "Support Custom Bingo",
+    "paywallTitle": "Apoya Custom Bingo",
     "@paywallTitle": {
         "description": "AppBar title of the direct-support paywall"
     },
-    "paywallThankYouTitle": "Thank you",
+    "paywallThankYouTitle": "Gracias",
     "@paywallThankYouTitle": {
         "description": "Paywall title shown after Pro access is active"
     },
-    "paywallSupportTitle": "Support Custom Bingo",
+    "paywallSupportTitle": "Apoya Custom Bingo",
     "@paywallSupportTitle": {
         "description": "Main title on the direct-support paywall"
     },
-    "paywallSupportBody": "This purchase supports me, the developer, directly. You get my gratitude and a few small bonus things for your boards.",
+    "paywallSupportBody": "Esta compra me apoya directamente a mí, el desarrollador. Recibes mi agradecimiento y algunos pequeños extras para tus tableros.",
     "@paywallSupportBody": {
         "description": "Main body copy on the direct-support paywall"
     },
-    "paywallBonusGratitude": "My gratitude, sincerely.",
+    "paywallBonusGratitude": "Mi agradecimiento, de verdad.",
     "@paywallBonusGratitude": {
         "description": "First benefit line on the direct-support paywall"
     },
-    "paywallBonusColors": "A few extra board colors.",
+    "paywallBonusColors": "Algunos colores extra para tableros.",
     "@paywallBonusColors": {
         "description": "Second benefit line on the direct-support paywall"
     },
-    "paywallBonusExtras": "Small supporter extras over time.",
+    "paywallBonusExtras": "Pequeños extras para seguidores con el tiempo.",
     "@paywallBonusExtras": {
         "description": "Third benefit line on the direct-support paywall"
     },
-    "paywallFreeForever": "No one ever needs to pay for this app. Custom Bingo stays usable for everyone.",
+    "paywallFreeForever": "Nadie necesita pagar nunca por esta app. Custom Bingo seguirá siendo usable para todos.",
     "@paywallFreeForever": {
         "description": "Footer reassurance on the direct-support paywall"
     },
-    "paywallLoadingPrice": "Loading price",
+    "paywallLoadingPrice": "Cargando precio",
     "@paywallLoadingPrice": {
         "description": "Placeholder shown while the paywall price is loading"
     },
-    "paywallUnavailable": "Unavailable",
+    "paywallUnavailable": "No disponible",
     "@paywallUnavailable": {
         "description": "Paywall price/button text when purchases are unavailable"
     },
-    "paywallSupportOnce": "Support once",
+    "paywallSupportOnce": "Apoyar una vez",
     "@paywallSupportOnce": {
         "description": "Purchase button label on the direct-support paywall"
     },
-    "paywallRestorePurchase": "Restore purchase",
+    "paywallRestorePurchase": "Restaurar compra",
     "@paywallRestorePurchase": {
         "description": "Restore button label on the direct-support paywall"
     },
-    "paywallProActiveToast": "Custom Bingo Pro is active.",
+    "paywallProActiveToast": "Custom Bingo Pro está activo.",
     "@paywallProActiveToast": {
         "description": "Toast shown after a successful Pro purchase"
     },
-    "paywallPurchaseInactiveToast": "Purchase finished, but Pro is not active.",
+    "paywallPurchaseInactiveToast": "La compra terminó, pero Pro no está activo.",
     "@paywallPurchaseInactiveToast": {
         "description": "Toast shown if a purchase returns without Pro access"
     },
-    "paywallProRestoredToast": "Custom Bingo Pro restored.",
+    "paywallProRestoredToast": "Custom Bingo Pro restaurado.",
     "@paywallProRestoredToast": {
         "description": "Toast shown after restoring Pro access"
     },
-    "paywallNoPurchaseFoundToast": "No Pro purchase found.",
+    "paywallNoPurchaseFoundToast": "No se encontró ninguna compra Pro.",
     "@paywallNoPurchaseFoundToast": {
         "description": "Toast shown when restore finds no Pro access"
     },
-    "paywallPurchasesUnavailable": "Purchases are unavailable right now.",
+    "paywallPurchasesUnavailable": "Las compras no están disponibles ahora mismo.",
     "@paywallPurchasesUnavailable": {
         "description": "Fallback error text for a paywall purchase error"
     },
-    "paywallPlatformUnavailable": "Purchases are unavailable on this platform.",
+    "paywallPlatformUnavailable": "Las compras no están disponibles en esta plataforma.",
     "@paywallPlatformUnavailable": {
         "description": "Fallback paywall text when purchases are not configured for the platform"
     },
-    "paywallCouldNotLoad": "Could not load purchase information.",
+    "paywallCouldNotLoad": "No se pudo cargar la información de compra.",
     "@paywallCouldNotLoad": {
         "description": "Fallback paywall error text for an unknown purchase loading error"
     },
@@ -460,7 +498,7 @@
     "@shareTitle": {
         "description": "Title of the share dialog"
     },
-    "shareDialogPrompt": "How would you like to share?",
+    "shareDialogPrompt": "¿Cómo quieres compartir?",
     "@shareDialogPrompt": {
         "description": "Section header above the two share options"
     },
@@ -468,7 +506,7 @@
     "@shareImageOptionTitle": {
         "description": "Title of the image-share option in the share dialog"
     },
-    "shareImageOptionHelper": "Send a picture of your card. Anyone can see it — even without the app.",
+    "shareImageOptionHelper": "Envía una imagen de tu tarjeta. Cualquiera puede verla, incluso sin la app.",
     "@shareImageOptionHelper": {
         "description": "Helper text explaining what 'Share as image' does"
     },
@@ -480,15 +518,15 @@
     "@shareInviteOptionTitle": {
         "description": "Title of the play-together invite option"
     },
-    "shareInviteOptionHelper": "Send this link to your friends who also have this app installed. They get the same card and you can play together.",
+    "shareInviteOptionHelper": "Envía este enlace a tus amigos que también tengan esta app instalada. Recibirán la misma tarjeta y podréis jugar juntos.",
     "@shareInviteOptionHelper": {
         "description": "Helper text explaining what the invite link does"
     },
-    "shareInviteIncludeMarks": "Include my checkmarks",
+    "shareInviteIncludeMarks": "Incluir mis marcas",
     "@shareInviteIncludeMarks": {
         "description": "Toggle label: include the sender's marks in the invite"
     },
-    "shareInviteIncludeMarksHelper": "When on, your friends will see what you've already crossed off.",
+    "shareInviteIncludeMarksHelper": "Cuando esté activado, tus amigos verán lo que ya has tachado.",
     "@shareInviteIncludeMarksHelper": {
         "description": "Helper text under the include-checkmarks toggle"
     },
@@ -514,15 +552,15 @@
     "@close": {
         "description": "Generic close button"
     },
-    "shareSubject": "Bingo Card",
+    "shareSubject": "Tarjeta de bingo",
     "@shareSubject": {
         "description": "Subject/title used by the system share sheet"
     },
-    "importTitle": "A friend shared a bingo card with you",
+    "importTitle": "Un amigo compartió una tarjeta de bingo contigo",
     "@importTitle": {
         "description": "Title of the import-card screen shown to the receiver"
     },
-    "importBody": "Add it to your cards so you can play along?",
+    "importBody": "¿Añadirla a tus tarjetas para jugar?",
     "@importBody": {
         "description": "Body of the import-card screen"
     },
@@ -534,7 +572,7 @@
     "@importCancel": {
         "description": "Cancel button on the import-card screen"
     },
-    "importCollisionToast": "You already had a card with this name, so I added it as \"{newName}\".",
+    "importCollisionToast": "Ya tenías una tarjeta con este nombre, así que la añadí como \"{newName}\".",
     "@importCollisionToast": {
         "description": "Toast shown after silently renaming an imported card to avoid a collision",
         "placeholders": {
@@ -544,11 +582,11 @@
             }
         }
     },
-    "importBadLinkToast": "Sorry, this invite couldn't be opened. Ask your friend to send it again.",
+    "importBadLinkToast": "Lo siento, no se pudo abrir esta invitación. Pide a tu amigo que la envíe otra vez.",
     "@importBadLinkToast": {
         "description": "Toast shown when an invite link is malformed"
     },
-    "importOutdatedAppToast": "Update the app to open this invite.",
+    "importOutdatedAppToast": "Actualiza la app para abrir esta invitación.",
     "@importOutdatedAppToast": {
         "description": "Toast shown when an invite payload uses a newer schema"
     },
@@ -560,7 +598,7 @@
     "@toastSuccess": {
         "description": "Title of a success toast"
     },
-    "toastError": "Error",
+    "toastError": "Fallo",
     "@toastError": {
         "description": "Title of an error toast"
     },
@@ -582,55 +620,55 @@
             }
         }
     },
-    "screenshotCaptionPlaying": "Just a simple app to create bingo board.\n\nNo signup, no ads, fully free to use.",
+    "screenshotCaptionPlaying": "Una app sencilla para crear tableros de bingo.\\n\\nSin registro, sin anuncios y totalmente gratis.",
     "@screenshotCaptionPlaying": {
         "description": "Promotional caption for the screenshot showing a played bingo board"
     },
-    "screenshotCaptionCreate": "Literally just 2 screens to create a bingo grid.",
+    "screenshotCaptionCreate": "Literalmente solo dos pantallas para crear una cuadrícula de bingo.",
     "@screenshotCaptionCreate": {
         "description": "Promotional caption for the screenshot showing the new-board screen"
     },
-    "screenshotCaptionLocked": "That's it.",
+    "screenshotCaptionLocked": "Eso es todo.",
     "@screenshotCaptionLocked": {
         "description": "Promotional caption for the screenshot showing the locked board"
     },
-    "screenshotBoardName": "David's Wedding",
+    "screenshotBoardName": "La boda de David",
     "@screenshotBoardName": {
         "description": "Sample bingo board name used in generated screenshots"
     },
-    "screenshotTilePhoneDuringVows": "Phone during vows",
+    "screenshotTilePhoneDuringVows": "Teléfono durante los votos",
     "@screenshotTilePhoneDuringVows": {
         "description": "Sample bingo tile text used in generated screenshots"
     },
-    "screenshotTileChampagneSpilled": "Champagne spilled",
+    "screenshotTileChampagneSpilled": "Champán derramado",
     "@screenshotTileChampagneSpilled": {
         "description": "Sample bingo tile text used in generated screenshots"
     },
-    "screenshotTileSpeechTears": "Speech tears",
+    "screenshotTileSpeechTears": "Lágrimas en el discurso",
     "@screenshotTileSpeechTears": {
         "description": "Sample bingo tile text used in generated screenshots"
     },
-    "screenshotTileDramaticEntrance": "Dramatic entrance",
+    "screenshotTileDramaticEntrance": "Entrada dramática",
     "@screenshotTileDramaticEntrance": {
         "description": "Sample bingo tile text used in generated screenshots"
     },
-    "screenshotTileKidsDanceFloor": "Kids take the dance floor",
+    "screenshotTileKidsDanceFloor": "Niños en la pista",
     "@screenshotTileKidsDanceFloor": {
         "description": "Sample bingo tile text used in generated screenshots"
     },
-    "screenshotTileGuestToast": "Guest gives a toast",
+    "screenshotTileGuestToast": "Un invitado brinda",
     "@screenshotTileGuestToast": {
         "description": "Sample bingo tile text used in generated screenshots"
     },
-    "screenshotTileCrowdClapsEarly": "Crowd claps early",
+    "screenshotTileCrowdClapsEarly": "Aplausos antes de tiempo",
     "@screenshotTileCrowdClapsEarly": {
         "description": "Sample bingo tile text used in generated screenshots"
     },
-    "screenshotTileDjClassic": "DJ plays a classic",
+    "screenshotTileDjClassic": "El DJ pone un clásico",
     "@screenshotTileDjClassic": {
         "description": "Sample bingo tile text used in generated screenshots"
     },
-    "screenshotTileGroupPhotoChaos": "Group photo chaos",
+    "screenshotTileGroupPhotoChaos": "Caos en la foto de grupo",
     "@screenshotTileGroupPhotoChaos": {
         "description": "Sample bingo tile text used in generated screenshots"
     }

--- a/lib/l10n/arb/app_es.arb
+++ b/lib/l10n/arb/app_es.arb
@@ -1,0 +1,637 @@
+{
+    "@@locale": "es",
+    "newCardTitle": "Crear nueva cuadrícula de bingo",
+    "@newCardTitle": {
+        "description": "AppBar title of the new-card screen"
+    },
+    "editCardTitle": "Editar cuadrícula de bingo",
+    "@editCardTitle": {
+        "description": "AppBar title of the edit-card screen"
+    },
+    "cardNameLabel": "Nombre de la cuadrícula *",
+    "@cardNameLabel": {
+        "description": "Label of the card-name text field"
+    },
+    "cardNameHint": "Ponle nombre a tu cuadrícula de bingo",
+    "@cardNameHint": {
+        "description": "Placeholder hint for the card-name text field"
+    },
+    "createCardButton": "Crear cuadrícula",
+    "@createCardButton": {
+        "description": "Confirm button on the new-card screen"
+    },
+    "updateCardButton": "Actualizar cuadrícula",
+    "@updateCardButton": {
+        "description": "Confirm button on the edit-card screen"
+    },
+    "newBoardPreMadeSectionTitle": "Your pre-made items",
+    "@newBoardPreMadeSectionTitle": {
+        "description": "Expandable section title for pre-made items on the new-board screen"
+    },
+    "newBoardPreMadeButton": "Start with pre-made items",
+    "@newBoardPreMadeButton": {
+        "description": "Button that opens pre-made item selection from the new-board screen"
+    },
+    "newBoardPreMadeChangeButton": "Change pre-made items",
+    "@newBoardPreMadeChangeButton": {
+        "description": "Button that reopens pre-made item selection after items have been applied"
+    },
+    "newBoardPreMadeClearButton": "Clear pre-made items",
+    "@newBoardPreMadeClearButton": {
+        "description": "Button that clears applied pre-made entries from the new-board form"
+    },
+    "newBoardPreMadeAppliedCount": "{count} pre-made entries applied",
+    "@newBoardPreMadeAppliedCount": {
+        "description": "Summary of how many pre-made entries are applied to the new-board form",
+        "placeholders": {
+            "count": {
+                "type": "int",
+                "example": "40"
+            }
+        }
+    },
+    "newBoardPreMadeFullSummary": "{used} will be drawn at random for this board.",
+    "@newBoardPreMadeFullSummary": {
+        "description": "Summary when applied pre-made entries can fill the new board",
+        "placeholders": {
+            "used": {
+                "type": "int",
+                "example": "25"
+            }
+        }
+    },
+    "newBoardPreMadePartialSummary": "{used} cells will be filled. {blank} will stay blank.",
+    "@newBoardPreMadePartialSummary": {
+        "description": "Summary when applied pre-made entries are fewer than the board cells",
+        "placeholders": {
+            "used": {
+                "type": "int",
+                "example": "10"
+            },
+            "blank": {
+                "type": "int",
+                "example": "15"
+            }
+        }
+    },
+    "defaultCardName": "Tarjeta de bingo",
+    "@defaultCardName": {
+        "description": "Fallback title shown when a card has no name"
+    },
+    "toggleHint": "Mantén pulsado para marcar una casilla",
+    "@toggleHint": {
+        "description": "Hint banner above the bingo grid"
+    },
+    "editingHintBefore": "Press the lock icon",
+    "@editingHintBefore": {
+        "description": "First half of the hint that explains the lock toggle. The lock icon is rendered between the two halves."
+    },
+    "editingHintAfter": " to make the fields not editable anymore.",
+    "@editingHintAfter": {
+        "description": "Second half of the lock-toggle hint, rendered after the lock icon."
+    },
+    "deleteCardTitle": "Delete Card",
+    "@deleteCardTitle": {
+        "description": "Title of the delete-card confirmation dialog"
+    },
+    "deleteCardConfirm": "Are you sure you want to delete this card?",
+    "@deleteCardConfirm": {
+        "description": "Body of the delete-card confirmation dialog"
+    },
+    "cancel": "Cancelar",
+    "@cancel": {
+        "description": "Generic cancel button"
+    },
+    "delete": "Eliminar",
+    "@delete": {
+        "description": "Generic delete button"
+    },
+    "shuffleCardTitle": "Shuffle Card",
+    "@shuffleCardTitle": {
+        "description": "Title of the shuffle confirmation dialog"
+    },
+    "shuffleCardConfirm": "Are you sure you want to shuffle this card? All fields will be unchecked, after shuffling.",
+    "@shuffleCardConfirm": {
+        "description": "Body of the shuffle confirmation dialog"
+    },
+    "shuffle": "Mezclar",
+    "@shuffle": {
+        "description": "Confirm button to shuffle the card"
+    },
+    "ratingPromptTitle": "Do you like Custom Bingo?",
+    "@ratingPromptTitle": {
+        "description": "Title of the dialog shown before asking for an app store review"
+    },
+    "ratingPromptBody": "If so, a quick store review helps others find it.",
+    "@ratingPromptBody": {
+        "description": "Body of the dialog shown before asking for an app store review"
+    },
+    "ratingPromptNo": "Not really",
+    "@ratingPromptNo": {
+        "description": "Dismiss button for the rating prompt dialog"
+    },
+    "ratingPromptYes": "Yes, I like it",
+    "@ratingPromptYes": {
+        "description": "Confirm button that continues to the native app store review flow"
+    },
+    "boardActionShare": "Compartir",
+    "@boardActionShare": {
+        "description": "Menu item that opens the share dialog from the board action bar"
+    },
+    "boardActionEditBoard": "Editar tablero",
+    "@boardActionEditBoard": {
+        "description": "Menu item that opens the board edit flow from the board action bar"
+    },
+    "boardActionAddPreMadeItems": "Add pre-made items",
+    "@boardActionAddPreMadeItems": {
+        "description": "Debug menu item placeholder for filling a board with pre-made items"
+    },
+    "cellHint": "Escribe texto…",
+    "@cellHint": {
+        "description": "Placeholder for an empty bingo cell"
+    },
+    "edit": "Editar",
+    "@edit": {
+        "description": "Edit menu item in a cell's context menu"
+    },
+    "markDone": "Mark Done",
+    "@markDone": {
+        "description": "Cell context menu item: mark this cell as done"
+    },
+    "markNotDone": "Mark Not Done",
+    "@markNotDone": {
+        "description": "Cell context menu item: clear the done state"
+    },
+    "newCardMenuItem": "Nuevo tablero de bingo",
+    "@newCardMenuItem": {
+        "description": "Menu item that opens the new-card screen"
+    },
+    "yourCardsHeader": "Tus tableros",
+    "@yourCardsHeader": {
+        "description": "Section header in the popup menu listing saved cards"
+    },
+    "settingsHeader": "Ajustes",
+    "@settingsHeader": {
+        "description": "Section header in the popup menu"
+    },
+    "appearanceMenuItem": "Appearance",
+    "@appearanceMenuItem": {
+        "description": "Menu item that opens the appearance settings screen"
+    },
+    "settingsAppearanceSection": "Apariencia",
+    "@settingsAppearanceSection": {
+        "description": "Section title for appearance settings"
+    },
+    "settingsPreferencesSection": "Preferencias",
+    "@settingsPreferencesSection": {
+        "description": "Section title for general preference settings"
+    },
+    "settingsBoardsSection": "Tableros",
+    "@settingsBoardsSection": {
+        "description": "Section title for board-related settings"
+    },
+    "settingsHelpSection": "Más",
+    "@settingsHelpSection": {
+        "description": "Section title for additional settings, help, and support entries"
+    },
+    "settingsSupportSection": "Apoyo",
+    "@settingsSupportSection": {
+        "description": "Section title for supporting the developer"
+    },
+    "themeColorLabel": "Color del tema",
+    "@themeColorLabel": {
+        "description": "Label above the theme color selector in settings"
+    },
+    "themeColorSettingsDescription": "Elige la paleta usada en toda la app.",
+    "@themeColorSettingsDescription": {
+        "description": "Settings helper text for the theme color selector"
+    },
+    "languageSettingsTitle": "Idioma",
+    "@languageSettingsTitle": {
+        "description": "Settings tile title for choosing the app language"
+    },
+    "languageSettingsSelectorLabel": "Idioma de la app",
+    "@languageSettingsSelectorLabel": {
+        "description": "Label above the language dropdown in settings"
+    },
+    "languageSettingsSystemOption": "Predeterminado del sistema ({language})",
+    "@languageSettingsSystemOption": {
+        "description": "Dropdown option that makes the app follow the phone/system language. The placeholder is the current phone language display name.",
+        "placeholders": {
+            "language": {
+                "type": "String",
+                "example": "Deutsch"
+            }
+        }
+    },
+    "languageSettingsSystemDescription": "Sigue el idioma del teléfono: {language}.",
+    "@languageSettingsSystemDescription": {
+        "description": "Settings helper text when no manual app language override is selected. The placeholder is the current phone language display name.",
+        "placeholders": {
+            "language": {
+                "type": "String",
+                "example": "Deutsch"
+            }
+        }
+    },
+    "languageSettingsOverrideDescription": "Usar este idioma en lugar del idioma del teléfono.",
+    "@languageSettingsOverrideDescription": {
+        "description": "Settings helper text when a manual app language override is selected"
+    },
+    "darkModeLabel": "Modo oscuro",
+    "@darkModeLabel": {
+        "description": "Label for the dark mode switch in settings"
+    },
+    "darkModeSettingsDescription": "Usar una interfaz más oscura.",
+    "@darkModeSettingsDescription": {
+        "description": "Settings helper text for the dark mode switch"
+    },
+    "enableConfettiLabel": "Confeti",
+    "@enableConfettiLabel": {
+        "description": "Label for the confetti preference switch"
+    },
+    "enableConfettiSettingsDescription": "Mostrar una celebración al completar un bingo.",
+    "@enableConfettiSettingsDescription": {
+        "description": "Settings helper text for the confetti preference switch"
+    },
+    "preMadeTilesTitle": "Pre-made tiles",
+    "@preMadeTilesTitle": {
+        "description": "Title of the pre-made tiles settings screen and menu entry"
+    },
+    "preMadeTilesSettingsDescription": "Create reusable tile text for future boards.",
+    "@preMadeTilesSettingsDescription": {
+        "description": "Settings entry helper text for pre-made tiles"
+    },
+    "preMadeTilesDescription": "Create reusable bingo entries here. When you create a new board, you can add them without typing everything again.",
+    "@preMadeTilesDescription": {
+        "description": "Description shown below the pre-made tiles screen title"
+    },
+    "preMadeTilesSelectMode": "Select",
+    "@preMadeTilesSelectMode": {
+        "description": "Segmented control label for selecting pre-made tiles"
+    },
+    "preMadeTilesEditMode": "Edit",
+    "@preMadeTilesEditMode": {
+        "description": "Segmented control label for editing pre-made tiles"
+    },
+    "preMadeTileHint": "Tile text",
+    "@preMadeTileHint": {
+        "description": "Placeholder for a pre-made tile text field"
+    },
+    "preMadeTilesAdd": "Add tile",
+    "@preMadeTilesAdd": {
+        "description": "Accessible label and tooltip for adding a pre-made tile"
+    },
+    "preMadeTilesDelete": "Delete tile",
+    "@preMadeTilesDelete": {
+        "description": "Accessible label and tooltip for deleting a pre-made tile"
+    },
+    "preMadeTilesSelectAll": "Un/select all",
+    "@preMadeTilesSelectAll": {
+        "description": "Checkbox label for toggling all pre-made tile selections"
+    },
+    "preMadeTilesSelectNone": "Select none",
+    "@preMadeTilesSelectNone": {
+        "description": "Button label for clearing all selected pre-made tiles"
+    },
+    "preMadeTilesApply": "Apply",
+    "@preMadeTilesApply": {
+        "description": "Button label for applying selected pre-made tiles to a board"
+    },
+    "preMadeTilesReplaceItems": "Replace items",
+    "@preMadeTilesReplaceItems": {
+        "description": "Button label for replacing current board items with selected pre-made items"
+    },
+    "preMadeTilesFillItems": "Fill items",
+    "@preMadeTilesFillItems": {
+        "description": "Button label for filling empty board items with selected pre-made items"
+    },
+    "preMadeTilesBoardActionHelp": "Replace swaps the board entries with a random draw from your selection. Fill only adds items to empty tiles. On odd boards, the center tile stays in place.",
+    "@preMadeTilesBoardActionHelp": {
+        "description": "Helper text explaining replace and fill actions for pre-made items on an existing board"
+    },
+    "preMadeTilesSelectedCount": "{selected} / {total} selected",
+    "@preMadeTilesSelectedCount": {
+        "description": "Count of selected pre-made tiles",
+        "placeholders": {
+            "selected": {
+                "type": "int",
+                "example": "12"
+            },
+            "total": {
+                "type": "int",
+                "example": "24"
+            }
+        }
+    },
+    "preMadeTilesEmptyTitle": "No tiles yet",
+    "@preMadeTilesEmptyTitle": {
+        "description": "Empty-state title for the pre-made tiles screen"
+    },
+    "preMadeTilesEmptyBody": "Add a tile to start building a reusable list.",
+    "@preMadeTilesEmptyBody": {
+        "description": "Empty-state helper text for the pre-made tiles screen"
+    },
+    "proposeFeatures": "Propose Features",
+    "@proposeFeatures": {
+        "description": "Menu item that opens the UserOrient feedback board"
+    },
+    "proposeFeaturesSettingsDescription": "Vote on ideas and suggest what to build next.",
+    "@proposeFeaturesSettingsDescription": {
+        "description": "Settings helper text for the feature request entry"
+    },
+    "supportMeDirectly": "Support the developer",
+    "@supportMeDirectly": {
+        "description": "Menu item that opens the direct-support paywall"
+    },
+    "supportMeDirectlySettingsDescription": "Help fund development and keep the app improving.",
+    "@supportMeDirectlySettingsDescription": {
+        "description": "Settings helper text for the direct support entry"
+    },
+    "supportCarouselProTitle": "Support Custom Bingo",
+    "@supportCarouselProTitle": {
+        "description": "Title of the home-screen support carousel item that opens the paywall"
+    },
+    "supportCarouselProSubtitle": "Unlock bonus colors and help keep the app independent.",
+    "@supportCarouselProSubtitle": {
+        "description": "Subtitle of the home-screen support carousel item that opens the paywall"
+    },
+    "supportCarouselRateTitle": "Enjoying the app?",
+    "@supportCarouselRateTitle": {
+        "description": "Title of the home-screen support carousel item that asks for a store review"
+    },
+    "supportCarouselRateSubtitle": "A quick review helps more people find Custom Bingo.",
+    "@supportCarouselRateSubtitle": {
+        "description": "Subtitle of the home-screen support carousel item that asks for a store review"
+    },
+    "rateTheApp": "Rate the app",
+    "@rateTheApp": {
+        "description": "Settings entry that opens the native store rating dialog"
+    },
+    "rateTheAppSettingsDescription": "Open the store rating prompt.",
+    "@rateTheAppSettingsDescription": {
+        "description": "Settings helper text for the app rating entry"
+    },
+    "contactMe": "Contact me",
+    "@contactMe": {
+        "description": "Settings entry that opens an email composer"
+    },
+    "contactMeSettingsDescription": "Send feedback, questions, or bug reports by email.",
+    "@contactMeSettingsDescription": {
+        "description": "Settings helper text for the contact email entry"
+    },
+    "paywallTitle": "Support Custom Bingo",
+    "@paywallTitle": {
+        "description": "AppBar title of the direct-support paywall"
+    },
+    "paywallThankYouTitle": "Thank you",
+    "@paywallThankYouTitle": {
+        "description": "Paywall title shown after Pro access is active"
+    },
+    "paywallSupportTitle": "Support Custom Bingo",
+    "@paywallSupportTitle": {
+        "description": "Main title on the direct-support paywall"
+    },
+    "paywallSupportBody": "This purchase supports me, the developer, directly. You get my gratitude and a few small bonus things for your boards.",
+    "@paywallSupportBody": {
+        "description": "Main body copy on the direct-support paywall"
+    },
+    "paywallBonusGratitude": "My gratitude, sincerely.",
+    "@paywallBonusGratitude": {
+        "description": "First benefit line on the direct-support paywall"
+    },
+    "paywallBonusColors": "A few extra board colors.",
+    "@paywallBonusColors": {
+        "description": "Second benefit line on the direct-support paywall"
+    },
+    "paywallBonusExtras": "Small supporter extras over time.",
+    "@paywallBonusExtras": {
+        "description": "Third benefit line on the direct-support paywall"
+    },
+    "paywallFreeForever": "No one ever needs to pay for this app. Custom Bingo stays usable for everyone.",
+    "@paywallFreeForever": {
+        "description": "Footer reassurance on the direct-support paywall"
+    },
+    "paywallLoadingPrice": "Loading price",
+    "@paywallLoadingPrice": {
+        "description": "Placeholder shown while the paywall price is loading"
+    },
+    "paywallUnavailable": "Unavailable",
+    "@paywallUnavailable": {
+        "description": "Paywall price/button text when purchases are unavailable"
+    },
+    "paywallSupportOnce": "Support once",
+    "@paywallSupportOnce": {
+        "description": "Purchase button label on the direct-support paywall"
+    },
+    "paywallRestorePurchase": "Restore purchase",
+    "@paywallRestorePurchase": {
+        "description": "Restore button label on the direct-support paywall"
+    },
+    "paywallProActiveToast": "Custom Bingo Pro is active.",
+    "@paywallProActiveToast": {
+        "description": "Toast shown after a successful Pro purchase"
+    },
+    "paywallPurchaseInactiveToast": "Purchase finished, but Pro is not active.",
+    "@paywallPurchaseInactiveToast": {
+        "description": "Toast shown if a purchase returns without Pro access"
+    },
+    "paywallProRestoredToast": "Custom Bingo Pro restored.",
+    "@paywallProRestoredToast": {
+        "description": "Toast shown after restoring Pro access"
+    },
+    "paywallNoPurchaseFoundToast": "No Pro purchase found.",
+    "@paywallNoPurchaseFoundToast": {
+        "description": "Toast shown when restore finds no Pro access"
+    },
+    "paywallPurchasesUnavailable": "Purchases are unavailable right now.",
+    "@paywallPurchasesUnavailable": {
+        "description": "Fallback error text for a paywall purchase error"
+    },
+    "paywallPlatformUnavailable": "Purchases are unavailable on this platform.",
+    "@paywallPlatformUnavailable": {
+        "description": "Fallback paywall text when purchases are not configured for the platform"
+    },
+    "paywallCouldNotLoad": "Could not load purchase information.",
+    "@paywallCouldNotLoad": {
+        "description": "Fallback paywall error text for an unknown purchase loading error"
+    },
+    "shareTitle": "Compartir la tarjeta de bingo",
+    "@shareTitle": {
+        "description": "Title of the share dialog"
+    },
+    "shareDialogPrompt": "How would you like to share?",
+    "@shareDialogPrompt": {
+        "description": "Section header above the two share options"
+    },
+    "shareImageOptionTitle": "Compartir como imagen",
+    "@shareImageOptionTitle": {
+        "description": "Title of the image-share option in the share dialog"
+    },
+    "shareImageOptionHelper": "Send a picture of your card. Anyone can see it — even without the app.",
+    "@shareImageOptionHelper": {
+        "description": "Helper text explaining what 'Share as image' does"
+    },
+    "shareImageOptionButton": "Compartir imagen",
+    "@shareImageOptionButton": {
+        "description": "Confirm button on the image-share option"
+    },
+    "shareInviteOptionTitle": "Invitar amigos a jugar",
+    "@shareInviteOptionTitle": {
+        "description": "Title of the play-together invite option"
+    },
+    "shareInviteOptionHelper": "Send this link to your friends who also have this app installed. They get the same card and you can play together.",
+    "@shareInviteOptionHelper": {
+        "description": "Helper text explaining what the invite link does"
+    },
+    "shareInviteIncludeMarks": "Include my checkmarks",
+    "@shareInviteIncludeMarks": {
+        "description": "Toggle label: include the sender's marks in the invite"
+    },
+    "shareInviteIncludeMarksHelper": "When on, your friends will see what you've already crossed off.",
+    "@shareInviteIncludeMarksHelper": {
+        "description": "Helper text under the include-checkmarks toggle"
+    },
+    "shareInviteOptionButton": "Enviar invitación",
+    "@shareInviteOptionButton": {
+        "description": "Confirm button on the invite-link option"
+    },
+    "shareInviteText": "¡Juega “{name}” conmigo! Ábrelo en la app:\n{link}",
+    "@shareInviteText": {
+        "description": "Body text passed to the system share sheet alongside the invite link",
+        "placeholders": {
+            "name": {
+                "type": "String",
+                "example": "Dateline BINGO"
+            },
+            "link": {
+                "type": "String",
+                "example": "https://bingogrid.web.app/import?d=…"
+            }
+        }
+    },
+    "close": "Cerrar",
+    "@close": {
+        "description": "Generic close button"
+    },
+    "shareSubject": "Bingo Card",
+    "@shareSubject": {
+        "description": "Subject/title used by the system share sheet"
+    },
+    "importTitle": "A friend shared a bingo card with you",
+    "@importTitle": {
+        "description": "Title of the import-card screen shown to the receiver"
+    },
+    "importBody": "Add it to your cards so you can play along?",
+    "@importBody": {
+        "description": "Body of the import-card screen"
+    },
+    "importConfirm": "Añadir a mis tarjetas",
+    "@importConfirm": {
+        "description": "Confirm button on the import-card screen"
+    },
+    "importCancel": "Ahora no",
+    "@importCancel": {
+        "description": "Cancel button on the import-card screen"
+    },
+    "importCollisionToast": "You already had a card with this name, so I added it as \"{newName}\".",
+    "@importCollisionToast": {
+        "description": "Toast shown after silently renaming an imported card to avoid a collision",
+        "placeholders": {
+            "newName": {
+                "type": "String",
+                "example": "Dateline BINGO (2)"
+            }
+        }
+    },
+    "importBadLinkToast": "Sorry, this invite couldn't be opened. Ask your friend to send it again.",
+    "@importBadLinkToast": {
+        "description": "Toast shown when an invite link is malformed"
+    },
+    "importOutdatedAppToast": "Update the app to open this invite.",
+    "@importOutdatedAppToast": {
+        "description": "Toast shown when an invite payload uses a newer schema"
+    },
+    "toastInfo": "Información",
+    "@toastInfo": {
+        "description": "Title of an informational toast"
+    },
+    "toastSuccess": "Éxito",
+    "@toastSuccess": {
+        "description": "Title of a success toast"
+    },
+    "toastError": "Error",
+    "@toastError": {
+        "description": "Title of an error toast"
+    },
+    "lastChangeNever": "Último cambio: nunca",
+    "@lastChangeNever": {
+        "description": "Footer line shown when a card has never been edited"
+    },
+    "lastChange": "Último cambio: {date} {time}",
+    "@lastChange": {
+        "description": "Footer line showing when the card was last edited",
+        "placeholders": {
+            "date": {
+                "type": "String",
+                "example": "5.5.2026"
+            },
+            "time": {
+                "type": "String",
+                "example": "14:30"
+            }
+        }
+    },
+    "screenshotCaptionPlaying": "Just a simple app to create bingo board.\n\nNo signup, no ads, fully free to use.",
+    "@screenshotCaptionPlaying": {
+        "description": "Promotional caption for the screenshot showing a played bingo board"
+    },
+    "screenshotCaptionCreate": "Literally just 2 screens to create a bingo grid.",
+    "@screenshotCaptionCreate": {
+        "description": "Promotional caption for the screenshot showing the new-board screen"
+    },
+    "screenshotCaptionLocked": "That's it.",
+    "@screenshotCaptionLocked": {
+        "description": "Promotional caption for the screenshot showing the locked board"
+    },
+    "screenshotBoardName": "David's Wedding",
+    "@screenshotBoardName": {
+        "description": "Sample bingo board name used in generated screenshots"
+    },
+    "screenshotTilePhoneDuringVows": "Phone during vows",
+    "@screenshotTilePhoneDuringVows": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileChampagneSpilled": "Champagne spilled",
+    "@screenshotTileChampagneSpilled": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileSpeechTears": "Speech tears",
+    "@screenshotTileSpeechTears": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileDramaticEntrance": "Dramatic entrance",
+    "@screenshotTileDramaticEntrance": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileKidsDanceFloor": "Kids take the dance floor",
+    "@screenshotTileKidsDanceFloor": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileGuestToast": "Guest gives a toast",
+    "@screenshotTileGuestToast": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileCrowdClapsEarly": "Crowd claps early",
+    "@screenshotTileCrowdClapsEarly": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileDjClassic": "DJ plays a classic",
+    "@screenshotTileDjClassic": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileGroupPhotoChaos": "Group photo chaos",
+    "@screenshotTileGroupPhotoChaos": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    }
+}

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -118,19 +118,19 @@
     "@shuffle": {
         "description": "Confirm button to shuffle the card"
     },
-    "ratingPromptTitle": "Do you like Custom Bingo?",
+    "ratingPromptTitle": "Vous aimez Custom Bingo ?",
     "@ratingPromptTitle": {
         "description": "Title of the dialog shown before asking for an app store review"
     },
-    "ratingPromptBody": "If so, a quick store review helps others find it.",
+    "ratingPromptBody": "Si oui, un avis rapide sur le store aide d’autres personnes à le trouver.",
     "@ratingPromptBody": {
         "description": "Body of the dialog shown before asking for an app store review"
     },
-    "ratingPromptNo": "Not really",
+    "ratingPromptNo": "Pas vraiment",
     "@ratingPromptNo": {
         "description": "Dismiss button for the rating prompt dialog"
     },
-    "ratingPromptYes": "Yes, I like it",
+    "ratingPromptYes": "Oui, j’aime",
     "@ratingPromptYes": {
         "description": "Confirm button that continues to the native app store review flow"
     },
@@ -142,7 +142,7 @@
     "@boardActionEditBoard": {
         "description": "Menu item that opens the board edit flow from the board action bar"
     },
-    "boardActionAddPreMadeItems": "Add pre-made items",
+    "boardActionAddPreMadeItems": "Ajouter des éléments préparés",
     "@boardActionAddPreMadeItems": {
         "description": "Debug menu item placeholder for filling a board with pre-made items"
     },
@@ -166,13 +166,51 @@
     "@newCardMenuItem": {
         "description": "Menu item that opens the new-card screen"
     },
+    "allBoardsMenuItem": "Toutes les grilles",
+    "@allBoardsMenuItem": {
+        "description": "Menu item that opens the list of all saved boards"
+    },
     "yourCardsHeader": "Vos grilles",
     "@yourCardsHeader": {
         "description": "Section header in the popup menu listing saved cards"
     },
+    "noBoardsYet": "Aucune grille pour l’instant",
+    "@noBoardsYet": {
+        "description": "Empty-state title shown when there are no saved boards"
+    },
+    "pageNotFoundTitle": "Page introuvable",
+    "@pageNotFoundTitle": {
+        "description": "Title shown on the fallback route when a page cannot be found"
+    },
+    "homeButton": "Accueil",
+    "@homeButton": {
+        "description": "Button that navigates back to the home screen"
+    },
+    "revenueCatUserIdLabel": "ID utilisateur RevenueCat : {userId}",
+    "@revenueCatUserIdLabel": {
+        "description": "Debug settings label showing the RevenueCat user id",
+        "placeholders": {
+            "userId": {
+                "type": "String",
+                "example": "abc123"
+            }
+        }
+    },
+    "copyRevenueCatUserIdTooltip": "Copier l’ID utilisateur RevenueCat",
+    "@copyRevenueCatUserIdTooltip": {
+        "description": "Tooltip for copying the RevenueCat user id from debug settings"
+    },
+    "revenueCatUserIdCopiedToast": "ID utilisateur RevenueCat copié.",
+    "@revenueCatUserIdCopiedToast": {
+        "description": "Toast shown after copying the RevenueCat user id"
+    },
     "settingsHeader": "Réglages",
     "@settingsHeader": {
         "description": "Section header in the popup menu"
+    },
+    "clearSettingsMenuItem": "Effacer les réglages",
+    "@clearSettingsMenuItem": {
+        "description": "Debug menu item that clears saved settings"
     },
     "appearanceMenuItem": "Apparence",
     "@appearanceMenuItem": {
@@ -306,11 +344,11 @@
     "@preMadeTilesFillItems": {
         "description": "Button label for filling empty board items with selected pre-made items"
     },
-    "preMadeTilesBoardActionHelp": "Replace swaps the board entries with a random draw from your selection. Fill only adds items to empty tiles. On odd boards, the center tile stays in place.",
+    "preMadeTilesBoardActionHelp": "Remplacer échange les entrées de la grille contre un tirage aléatoire de votre sélection. Remplir ajoute seulement des éléments aux cases vides. Sur les grilles impaires, la case centrale reste en place.",
     "@preMadeTilesBoardActionHelp": {
         "description": "Helper text explaining replace and fill actions for pre-made items on an existing board"
     },
-    "preMadeTilesSelectedCount": "{selected} / {total} selected",
+    "preMadeTilesSelectedCount": "{selected} / {total} sélectionnées",
     "@preMadeTilesSelectedCount": {
         "description": "Count of selected pre-made tiles",
         "placeholders": {
@@ -348,19 +386,19 @@
     "@supportMeDirectlySettingsDescription": {
         "description": "Settings helper text for the direct support entry"
     },
-    "supportCarouselProTitle": "Support Custom Bingo",
+    "supportCarouselProTitle": "Soutenir Custom Bingo",
     "@supportCarouselProTitle": {
         "description": "Title of the home-screen support carousel item that opens the paywall"
     },
-    "supportCarouselProSubtitle": "Unlock bonus colors and help keep the app independent.",
+    "supportCarouselProSubtitle": "Débloquez des couleurs bonus et aidez l’app à rester indépendante.",
     "@supportCarouselProSubtitle": {
         "description": "Subtitle of the home-screen support carousel item that opens the paywall"
     },
-    "supportCarouselRateTitle": "Enjoying the app?",
+    "supportCarouselRateTitle": "Vous aimez l’app ?",
     "@supportCarouselRateTitle": {
         "description": "Title of the home-screen support carousel item that asks for a store review"
     },
-    "supportCarouselRateSubtitle": "A quick review helps more people find Custom Bingo.",
+    "supportCarouselRateSubtitle": "Un avis rapide aide plus de personnes à découvrir Custom Bingo.",
     "@supportCarouselRateSubtitle": {
         "description": "Subtitle of the home-screen support carousel item that asks for a store review"
     },
@@ -380,79 +418,79 @@
     "@contactMeSettingsDescription": {
         "description": "Settings helper text for the contact email entry"
     },
-    "paywallTitle": "Support Custom Bingo",
+    "paywallTitle": "Soutenir Custom Bingo",
     "@paywallTitle": {
         "description": "AppBar title of the direct-support paywall"
     },
-    "paywallThankYouTitle": "Thank you",
+    "paywallThankYouTitle": "Merci",
     "@paywallThankYouTitle": {
         "description": "Paywall title shown after Pro access is active"
     },
-    "paywallSupportTitle": "Support Custom Bingo",
+    "paywallSupportTitle": "Soutenir Custom Bingo",
     "@paywallSupportTitle": {
         "description": "Main title on the direct-support paywall"
     },
-    "paywallSupportBody": "This purchase supports me, the developer, directly. You get my gratitude and a few small bonus things for your boards.",
+    "paywallSupportBody": "Cet achat me soutient directement, moi le développeur. Vous recevez ma gratitude et quelques petits bonus pour vos grilles.",
     "@paywallSupportBody": {
         "description": "Main body copy on the direct-support paywall"
     },
-    "paywallBonusGratitude": "My gratitude, sincerely.",
+    "paywallBonusGratitude": "Ma gratitude, sincèrement.",
     "@paywallBonusGratitude": {
         "description": "First benefit line on the direct-support paywall"
     },
-    "paywallBonusColors": "A few extra board colors.",
+    "paywallBonusColors": "Quelques couleurs de grille en plus.",
     "@paywallBonusColors": {
         "description": "Second benefit line on the direct-support paywall"
     },
-    "paywallBonusExtras": "Small supporter extras over time.",
+    "paywallBonusExtras": "De petits bonus de soutien au fil du temps.",
     "@paywallBonusExtras": {
         "description": "Third benefit line on the direct-support paywall"
     },
-    "paywallFreeForever": "No one ever needs to pay for this app. Custom Bingo stays usable for everyone.",
+    "paywallFreeForever": "Personne n’a jamais besoin de payer pour cette app. Custom Bingo reste utilisable par tout le monde.",
     "@paywallFreeForever": {
         "description": "Footer reassurance on the direct-support paywall"
     },
-    "paywallLoadingPrice": "Loading price",
+    "paywallLoadingPrice": "Chargement du prix",
     "@paywallLoadingPrice": {
         "description": "Placeholder shown while the paywall price is loading"
     },
-    "paywallUnavailable": "Unavailable",
+    "paywallUnavailable": "Indisponible",
     "@paywallUnavailable": {
         "description": "Paywall price/button text when purchases are unavailable"
     },
-    "paywallSupportOnce": "Support once",
+    "paywallSupportOnce": "Soutenir une fois",
     "@paywallSupportOnce": {
         "description": "Purchase button label on the direct-support paywall"
     },
-    "paywallRestorePurchase": "Restore purchase",
+    "paywallRestorePurchase": "Restaurer l’achat",
     "@paywallRestorePurchase": {
         "description": "Restore button label on the direct-support paywall"
     },
-    "paywallProActiveToast": "Custom Bingo Pro is active.",
+    "paywallProActiveToast": "Custom Bingo Pro est actif.",
     "@paywallProActiveToast": {
         "description": "Toast shown after a successful Pro purchase"
     },
-    "paywallPurchaseInactiveToast": "Purchase finished, but Pro is not active.",
+    "paywallPurchaseInactiveToast": "L’achat est terminé, mais Pro n’est pas actif.",
     "@paywallPurchaseInactiveToast": {
         "description": "Toast shown if a purchase returns without Pro access"
     },
-    "paywallProRestoredToast": "Custom Bingo Pro restored.",
+    "paywallProRestoredToast": "Custom Bingo Pro restauré.",
     "@paywallProRestoredToast": {
         "description": "Toast shown after restoring Pro access"
     },
-    "paywallNoPurchaseFoundToast": "No Pro purchase found.",
+    "paywallNoPurchaseFoundToast": "Aucun achat Pro trouvé.",
     "@paywallNoPurchaseFoundToast": {
         "description": "Toast shown when restore finds no Pro access"
     },
-    "paywallPurchasesUnavailable": "Purchases are unavailable right now.",
+    "paywallPurchasesUnavailable": "Les achats sont indisponibles pour le moment.",
     "@paywallPurchasesUnavailable": {
         "description": "Fallback error text for a paywall purchase error"
     },
-    "paywallPlatformUnavailable": "Purchases are unavailable on this platform.",
+    "paywallPlatformUnavailable": "Les achats ne sont pas disponibles sur cette plateforme.",
     "@paywallPlatformUnavailable": {
         "description": "Fallback paywall text when purchases are not configured for the platform"
     },
-    "paywallCouldNotLoad": "Could not load purchase information.",
+    "paywallCouldNotLoad": "Impossible de charger les informations d’achat.",
     "@paywallCouldNotLoad": {
         "description": "Fallback paywall error text for an unknown purchase loading error"
     },
@@ -480,7 +518,7 @@
     "@shareInviteOptionTitle": {
         "description": "Title of the play-together invite option"
     },
-    "shareInviteOptionHelper": "Send this link to your friends who also have this app installed. They get the same card and you can play together.",
+    "shareInviteOptionHelper": "Envoyez ce lien à vos amis qui ont aussi installé cette app. Ils recevront la même carte et vous pourrez jouer ensemble.",
     "@shareInviteOptionHelper": {
         "description": "Helper text explaining what the invite link does"
     },
@@ -534,7 +572,7 @@
     "@importCancel": {
         "description": "Cancel button on the import-card screen"
     },
-    "importCollisionToast": "You already had a card with this name, so I added it as \"{newName}\".",
+    "importCollisionToast": "Vous aviez déjà une carte avec ce nom, je l’ai donc ajoutée sous « {newName} ».",
     "@importCollisionToast": {
         "description": "Toast shown after silently renaming an imported card to avoid a collision",
         "placeholders": {
@@ -544,15 +582,15 @@
             }
         }
     },
-    "importBadLinkToast": "Sorry, this invite couldn't be opened. Ask your friend to send it again.",
+    "importBadLinkToast": "Désolé, cette invitation n’a pas pu être ouverte. Demandez à votre ami de la renvoyer.",
     "@importBadLinkToast": {
         "description": "Toast shown when an invite link is malformed"
     },
-    "importOutdatedAppToast": "Update the app to open this invite.",
+    "importOutdatedAppToast": "Mettez l’app à jour pour ouvrir cette invitation.",
     "@importOutdatedAppToast": {
         "description": "Toast shown when an invite payload uses a newer schema"
     },
-    "toastInfo": "Info",
+    "toastInfo": "Information",
     "@toastInfo": {
         "description": "Title of an informational toast"
     },

--- a/lib/l10n/arb/app_fr.arb
+++ b/lib/l10n/arb/app_fr.arb
@@ -1,0 +1,637 @@
+{
+    "@@locale": "fr",
+    "newCardTitle": "Créer une nouvelle grille de bingo",
+    "@newCardTitle": {
+        "description": "AppBar title of the new-card screen"
+    },
+    "editCardTitle": "Modifier la grille de bingo",
+    "@editCardTitle": {
+        "description": "AppBar title of the edit-card screen"
+    },
+    "cardNameLabel": "Nom de la grille *",
+    "@cardNameLabel": {
+        "description": "Label of the card-name text field"
+    },
+    "cardNameHint": "Donnez un nom à votre grille de bingo",
+    "@cardNameHint": {
+        "description": "Placeholder hint for the card-name text field"
+    },
+    "createCardButton": "Créer la grille",
+    "@createCardButton": {
+        "description": "Confirm button on the new-card screen"
+    },
+    "updateCardButton": "Mettre à jour la grille",
+    "@updateCardButton": {
+        "description": "Confirm button on the edit-card screen"
+    },
+    "newBoardPreMadeSectionTitle": "Vos éléments préparés",
+    "@newBoardPreMadeSectionTitle": {
+        "description": "Expandable section title for pre-made items on the new-board screen"
+    },
+    "newBoardPreMadeButton": "Commencer avec des éléments préparés",
+    "@newBoardPreMadeButton": {
+        "description": "Button that opens pre-made item selection from the new-board screen"
+    },
+    "newBoardPreMadeChangeButton": "Modifier les éléments préparés",
+    "@newBoardPreMadeChangeButton": {
+        "description": "Button that reopens pre-made item selection after items have been applied"
+    },
+    "newBoardPreMadeClearButton": "Effacer les éléments préparés",
+    "@newBoardPreMadeClearButton": {
+        "description": "Button that clears applied pre-made entries from the new-board form"
+    },
+    "newBoardPreMadeAppliedCount": "{count} entrées préparées appliquées",
+    "@newBoardPreMadeAppliedCount": {
+        "description": "Summary of how many pre-made entries are applied to the new-board form",
+        "placeholders": {
+            "count": {
+                "type": "int",
+                "example": "40"
+            }
+        }
+    },
+    "newBoardPreMadeFullSummary": "{used} seront tirées au hasard pour cette grille.",
+    "@newBoardPreMadeFullSummary": {
+        "description": "Summary when applied pre-made entries can fill the new board",
+        "placeholders": {
+            "used": {
+                "type": "int",
+                "example": "25"
+            }
+        }
+    },
+    "newBoardPreMadePartialSummary": "{used} cases seront remplies. {blank} resteront vides.",
+    "@newBoardPreMadePartialSummary": {
+        "description": "Summary when applied pre-made entries are fewer than the board cells",
+        "placeholders": {
+            "used": {
+                "type": "int",
+                "example": "10"
+            },
+            "blank": {
+                "type": "int",
+                "example": "15"
+            }
+        }
+    },
+    "defaultCardName": "Carte de bingo",
+    "@defaultCardName": {
+        "description": "Fallback title shown when a card has no name"
+    },
+    "toggleHint": "Appuyez longuement pour cocher une case",
+    "@toggleHint": {
+        "description": "Hint banner above the bingo grid"
+    },
+    "editingHintBefore": "Appuyez sur l’icône de cadenas",
+    "@editingHintBefore": {
+        "description": "First half of the hint that explains the lock toggle. The lock icon is rendered between the two halves."
+    },
+    "editingHintAfter": " pour empêcher la modification des cases.",
+    "@editingHintAfter": {
+        "description": "Second half of the lock-toggle hint, rendered after the lock icon."
+    },
+    "deleteCardTitle": "Supprimer la carte",
+    "@deleteCardTitle": {
+        "description": "Title of the delete-card confirmation dialog"
+    },
+    "deleteCardConfirm": "Voulez-vous vraiment supprimer cette carte ?",
+    "@deleteCardConfirm": {
+        "description": "Body of the delete-card confirmation dialog"
+    },
+    "cancel": "Annuler",
+    "@cancel": {
+        "description": "Generic cancel button"
+    },
+    "delete": "Supprimer",
+    "@delete": {
+        "description": "Generic delete button"
+    },
+    "shuffleCardTitle": "Mélanger la carte",
+    "@shuffleCardTitle": {
+        "description": "Title of the shuffle confirmation dialog"
+    },
+    "shuffleCardConfirm": "Voulez-vous vraiment mélanger cette carte ? Toutes les cases seront décochées après le mélange.",
+    "@shuffleCardConfirm": {
+        "description": "Body of the shuffle confirmation dialog"
+    },
+    "shuffle": "Mélanger",
+    "@shuffle": {
+        "description": "Confirm button to shuffle the card"
+    },
+    "ratingPromptTitle": "Do you like Custom Bingo?",
+    "@ratingPromptTitle": {
+        "description": "Title of the dialog shown before asking for an app store review"
+    },
+    "ratingPromptBody": "If so, a quick store review helps others find it.",
+    "@ratingPromptBody": {
+        "description": "Body of the dialog shown before asking for an app store review"
+    },
+    "ratingPromptNo": "Not really",
+    "@ratingPromptNo": {
+        "description": "Dismiss button for the rating prompt dialog"
+    },
+    "ratingPromptYes": "Yes, I like it",
+    "@ratingPromptYes": {
+        "description": "Confirm button that continues to the native app store review flow"
+    },
+    "boardActionShare": "Partager",
+    "@boardActionShare": {
+        "description": "Menu item that opens the share dialog from the board action bar"
+    },
+    "boardActionEditBoard": "Modifier la grille",
+    "@boardActionEditBoard": {
+        "description": "Menu item that opens the board edit flow from the board action bar"
+    },
+    "boardActionAddPreMadeItems": "Add pre-made items",
+    "@boardActionAddPreMadeItems": {
+        "description": "Debug menu item placeholder for filling a board with pre-made items"
+    },
+    "cellHint": "Saisir du texte…",
+    "@cellHint": {
+        "description": "Placeholder for an empty bingo cell"
+    },
+    "edit": "Modifier",
+    "@edit": {
+        "description": "Edit menu item in a cell's context menu"
+    },
+    "markDone": "Marquer comme fait",
+    "@markDone": {
+        "description": "Cell context menu item: mark this cell as done"
+    },
+    "markNotDone": "Retirer la marque",
+    "@markNotDone": {
+        "description": "Cell context menu item: clear the done state"
+    },
+    "newCardMenuItem": "Nouvelle grille de bingo",
+    "@newCardMenuItem": {
+        "description": "Menu item that opens the new-card screen"
+    },
+    "yourCardsHeader": "Vos grilles",
+    "@yourCardsHeader": {
+        "description": "Section header in the popup menu listing saved cards"
+    },
+    "settingsHeader": "Réglages",
+    "@settingsHeader": {
+        "description": "Section header in the popup menu"
+    },
+    "appearanceMenuItem": "Apparence",
+    "@appearanceMenuItem": {
+        "description": "Menu item that opens the appearance settings screen"
+    },
+    "settingsAppearanceSection": "Apparence",
+    "@settingsAppearanceSection": {
+        "description": "Section title for appearance settings"
+    },
+    "settingsPreferencesSection": "Préférences",
+    "@settingsPreferencesSection": {
+        "description": "Section title for general preference settings"
+    },
+    "settingsBoardsSection": "Grilles",
+    "@settingsBoardsSection": {
+        "description": "Section title for board-related settings"
+    },
+    "settingsHelpSection": "Plus",
+    "@settingsHelpSection": {
+        "description": "Section title for additional settings, help, and support entries"
+    },
+    "settingsSupportSection": "Soutien",
+    "@settingsSupportSection": {
+        "description": "Section title for supporting the developer"
+    },
+    "themeColorLabel": "Couleur du thème",
+    "@themeColorLabel": {
+        "description": "Label above the theme color selector in settings"
+    },
+    "themeColorSettingsDescription": "Choisissez la palette utilisée dans toute l’app.",
+    "@themeColorSettingsDescription": {
+        "description": "Settings helper text for the theme color selector"
+    },
+    "languageSettingsTitle": "Langue",
+    "@languageSettingsTitle": {
+        "description": "Settings tile title for choosing the app language"
+    },
+    "languageSettingsSelectorLabel": "Langue de l’app",
+    "@languageSettingsSelectorLabel": {
+        "description": "Label above the language dropdown in settings"
+    },
+    "languageSettingsSystemOption": "Par défaut du système ({language})",
+    "@languageSettingsSystemOption": {
+        "description": "Dropdown option that makes the app follow the phone/system language. The placeholder is the current phone language display name.",
+        "placeholders": {
+            "language": {
+                "type": "String",
+                "example": "Deutsch"
+            }
+        }
+    },
+    "languageSettingsSystemDescription": "Suit la langue de votre téléphone : {language}.",
+    "@languageSettingsSystemDescription": {
+        "description": "Settings helper text when no manual app language override is selected. The placeholder is the current phone language display name.",
+        "placeholders": {
+            "language": {
+                "type": "String",
+                "example": "Deutsch"
+            }
+        }
+    },
+    "languageSettingsOverrideDescription": "Utiliser cette langue au lieu de celle du téléphone.",
+    "@languageSettingsOverrideDescription": {
+        "description": "Settings helper text when a manual app language override is selected"
+    },
+    "darkModeLabel": "Mode sombre",
+    "@darkModeLabel": {
+        "description": "Label for the dark mode switch in settings"
+    },
+    "darkModeSettingsDescription": "Utiliser une interface plus sombre.",
+    "@darkModeSettingsDescription": {
+        "description": "Settings helper text for the dark mode switch"
+    },
+    "enableConfettiLabel": "Confettis",
+    "@enableConfettiLabel": {
+        "description": "Label for the confetti preference switch"
+    },
+    "enableConfettiSettingsDescription": "Afficher une célébration quand vous terminez un bingo.",
+    "@enableConfettiSettingsDescription": {
+        "description": "Settings helper text for the confetti preference switch"
+    },
+    "preMadeTilesTitle": "Cases préparées",
+    "@preMadeTilesTitle": {
+        "description": "Title of the pre-made tiles settings screen and menu entry"
+    },
+    "preMadeTilesSettingsDescription": "Créer des textes de case réutilisables pour de futures grilles.",
+    "@preMadeTilesSettingsDescription": {
+        "description": "Settings entry helper text for pre-made tiles"
+    },
+    "preMadeTilesDescription": "Créez ici des entrées de bingo réutilisables. Lors de la création d’une nouvelle grille, vous pourrez les ajouter sans tout retaper.",
+    "@preMadeTilesDescription": {
+        "description": "Description shown below the pre-made tiles screen title"
+    },
+    "preMadeTilesSelectMode": "Sélectionner",
+    "@preMadeTilesSelectMode": {
+        "description": "Segmented control label for selecting pre-made tiles"
+    },
+    "preMadeTilesEditMode": "Modifier",
+    "@preMadeTilesEditMode": {
+        "description": "Segmented control label for editing pre-made tiles"
+    },
+    "preMadeTileHint": "Texte de la case",
+    "@preMadeTileHint": {
+        "description": "Placeholder for a pre-made tile text field"
+    },
+    "preMadeTilesAdd": "Ajouter une case",
+    "@preMadeTilesAdd": {
+        "description": "Accessible label and tooltip for adding a pre-made tile"
+    },
+    "preMadeTilesDelete": "Supprimer la case",
+    "@preMadeTilesDelete": {
+        "description": "Accessible label and tooltip for deleting a pre-made tile"
+    },
+    "preMadeTilesSelectAll": "Tout sélectionner/désélectionner",
+    "@preMadeTilesSelectAll": {
+        "description": "Checkbox label for toggling all pre-made tile selections"
+    },
+    "preMadeTilesSelectNone": "Ne rien sélectionner",
+    "@preMadeTilesSelectNone": {
+        "description": "Button label for clearing all selected pre-made tiles"
+    },
+    "preMadeTilesApply": "Appliquer",
+    "@preMadeTilesApply": {
+        "description": "Button label for applying selected pre-made tiles to a board"
+    },
+    "preMadeTilesReplaceItems": "Remplacer les éléments",
+    "@preMadeTilesReplaceItems": {
+        "description": "Button label for replacing current board items with selected pre-made items"
+    },
+    "preMadeTilesFillItems": "Remplir les éléments",
+    "@preMadeTilesFillItems": {
+        "description": "Button label for filling empty board items with selected pre-made items"
+    },
+    "preMadeTilesBoardActionHelp": "Replace swaps the board entries with a random draw from your selection. Fill only adds items to empty tiles. On odd boards, the center tile stays in place.",
+    "@preMadeTilesBoardActionHelp": {
+        "description": "Helper text explaining replace and fill actions for pre-made items on an existing board"
+    },
+    "preMadeTilesSelectedCount": "{selected} / {total} selected",
+    "@preMadeTilesSelectedCount": {
+        "description": "Count of selected pre-made tiles",
+        "placeholders": {
+            "selected": {
+                "type": "int",
+                "example": "12"
+            },
+            "total": {
+                "type": "int",
+                "example": "24"
+            }
+        }
+    },
+    "preMadeTilesEmptyTitle": "Aucune case pour l’instant",
+    "@preMadeTilesEmptyTitle": {
+        "description": "Empty-state title for the pre-made tiles screen"
+    },
+    "preMadeTilesEmptyBody": "Ajoutez une case pour commencer une liste réutilisable.",
+    "@preMadeTilesEmptyBody": {
+        "description": "Empty-state helper text for the pre-made tiles screen"
+    },
+    "proposeFeatures": "Proposer des fonctionnalités",
+    "@proposeFeatures": {
+        "description": "Menu item that opens the UserOrient feedback board"
+    },
+    "proposeFeaturesSettingsDescription": "Votez pour des idées et suggérez la suite.",
+    "@proposeFeaturesSettingsDescription": {
+        "description": "Settings helper text for the feature request entry"
+    },
+    "supportMeDirectly": "Soutenir le développeur",
+    "@supportMeDirectly": {
+        "description": "Menu item that opens the direct-support paywall"
+    },
+    "supportMeDirectlySettingsDescription": "Aidez à financer le développement et à améliorer l’app.",
+    "@supportMeDirectlySettingsDescription": {
+        "description": "Settings helper text for the direct support entry"
+    },
+    "supportCarouselProTitle": "Support Custom Bingo",
+    "@supportCarouselProTitle": {
+        "description": "Title of the home-screen support carousel item that opens the paywall"
+    },
+    "supportCarouselProSubtitle": "Unlock bonus colors and help keep the app independent.",
+    "@supportCarouselProSubtitle": {
+        "description": "Subtitle of the home-screen support carousel item that opens the paywall"
+    },
+    "supportCarouselRateTitle": "Enjoying the app?",
+    "@supportCarouselRateTitle": {
+        "description": "Title of the home-screen support carousel item that asks for a store review"
+    },
+    "supportCarouselRateSubtitle": "A quick review helps more people find Custom Bingo.",
+    "@supportCarouselRateSubtitle": {
+        "description": "Subtitle of the home-screen support carousel item that asks for a store review"
+    },
+    "rateTheApp": "Noter l’app",
+    "@rateTheApp": {
+        "description": "Settings entry that opens the native store rating dialog"
+    },
+    "rateTheAppSettingsDescription": "Ouvrir la demande de note du store.",
+    "@rateTheAppSettingsDescription": {
+        "description": "Settings helper text for the app rating entry"
+    },
+    "contactMe": "Me contacter",
+    "@contactMe": {
+        "description": "Settings entry that opens an email composer"
+    },
+    "contactMeSettingsDescription": "Envoyer des retours, questions ou bugs par e-mail.",
+    "@contactMeSettingsDescription": {
+        "description": "Settings helper text for the contact email entry"
+    },
+    "paywallTitle": "Support Custom Bingo",
+    "@paywallTitle": {
+        "description": "AppBar title of the direct-support paywall"
+    },
+    "paywallThankYouTitle": "Thank you",
+    "@paywallThankYouTitle": {
+        "description": "Paywall title shown after Pro access is active"
+    },
+    "paywallSupportTitle": "Support Custom Bingo",
+    "@paywallSupportTitle": {
+        "description": "Main title on the direct-support paywall"
+    },
+    "paywallSupportBody": "This purchase supports me, the developer, directly. You get my gratitude and a few small bonus things for your boards.",
+    "@paywallSupportBody": {
+        "description": "Main body copy on the direct-support paywall"
+    },
+    "paywallBonusGratitude": "My gratitude, sincerely.",
+    "@paywallBonusGratitude": {
+        "description": "First benefit line on the direct-support paywall"
+    },
+    "paywallBonusColors": "A few extra board colors.",
+    "@paywallBonusColors": {
+        "description": "Second benefit line on the direct-support paywall"
+    },
+    "paywallBonusExtras": "Small supporter extras over time.",
+    "@paywallBonusExtras": {
+        "description": "Third benefit line on the direct-support paywall"
+    },
+    "paywallFreeForever": "No one ever needs to pay for this app. Custom Bingo stays usable for everyone.",
+    "@paywallFreeForever": {
+        "description": "Footer reassurance on the direct-support paywall"
+    },
+    "paywallLoadingPrice": "Loading price",
+    "@paywallLoadingPrice": {
+        "description": "Placeholder shown while the paywall price is loading"
+    },
+    "paywallUnavailable": "Unavailable",
+    "@paywallUnavailable": {
+        "description": "Paywall price/button text when purchases are unavailable"
+    },
+    "paywallSupportOnce": "Support once",
+    "@paywallSupportOnce": {
+        "description": "Purchase button label on the direct-support paywall"
+    },
+    "paywallRestorePurchase": "Restore purchase",
+    "@paywallRestorePurchase": {
+        "description": "Restore button label on the direct-support paywall"
+    },
+    "paywallProActiveToast": "Custom Bingo Pro is active.",
+    "@paywallProActiveToast": {
+        "description": "Toast shown after a successful Pro purchase"
+    },
+    "paywallPurchaseInactiveToast": "Purchase finished, but Pro is not active.",
+    "@paywallPurchaseInactiveToast": {
+        "description": "Toast shown if a purchase returns without Pro access"
+    },
+    "paywallProRestoredToast": "Custom Bingo Pro restored.",
+    "@paywallProRestoredToast": {
+        "description": "Toast shown after restoring Pro access"
+    },
+    "paywallNoPurchaseFoundToast": "No Pro purchase found.",
+    "@paywallNoPurchaseFoundToast": {
+        "description": "Toast shown when restore finds no Pro access"
+    },
+    "paywallPurchasesUnavailable": "Purchases are unavailable right now.",
+    "@paywallPurchasesUnavailable": {
+        "description": "Fallback error text for a paywall purchase error"
+    },
+    "paywallPlatformUnavailable": "Purchases are unavailable on this platform.",
+    "@paywallPlatformUnavailable": {
+        "description": "Fallback paywall text when purchases are not configured for the platform"
+    },
+    "paywallCouldNotLoad": "Could not load purchase information.",
+    "@paywallCouldNotLoad": {
+        "description": "Fallback paywall error text for an unknown purchase loading error"
+    },
+    "shareTitle": "Partager la carte de bingo",
+    "@shareTitle": {
+        "description": "Title of the share dialog"
+    },
+    "shareDialogPrompt": "Comment voulez-vous partager ?",
+    "@shareDialogPrompt": {
+        "description": "Section header above the two share options"
+    },
+    "shareImageOptionTitle": "Partager en image",
+    "@shareImageOptionTitle": {
+        "description": "Title of the image-share option in the share dialog"
+    },
+    "shareImageOptionHelper": "Envoyez une image de votre carte. Tout le monde peut la voir, même sans l’app.",
+    "@shareImageOptionHelper": {
+        "description": "Helper text explaining what 'Share as image' does"
+    },
+    "shareImageOptionButton": "Partager l’image",
+    "@shareImageOptionButton": {
+        "description": "Confirm button on the image-share option"
+    },
+    "shareInviteOptionTitle": "Inviter des amis à jouer",
+    "@shareInviteOptionTitle": {
+        "description": "Title of the play-together invite option"
+    },
+    "shareInviteOptionHelper": "Send this link to your friends who also have this app installed. They get the same card and you can play together.",
+    "@shareInviteOptionHelper": {
+        "description": "Helper text explaining what the invite link does"
+    },
+    "shareInviteIncludeMarks": "Inclure mes coches",
+    "@shareInviteIncludeMarks": {
+        "description": "Toggle label: include the sender's marks in the invite"
+    },
+    "shareInviteIncludeMarksHelper": "Activé, vos amis verront ce que vous avez déjà coché.",
+    "@shareInviteIncludeMarksHelper": {
+        "description": "Helper text under the include-checkmarks toggle"
+    },
+    "shareInviteOptionButton": "Envoyer l’invitation",
+    "@shareInviteOptionButton": {
+        "description": "Confirm button on the invite-link option"
+    },
+    "shareInviteText": "Joue à « {name} » avec moi ! Ouvre-le dans l’app :\n{link}",
+    "@shareInviteText": {
+        "description": "Body text passed to the system share sheet alongside the invite link",
+        "placeholders": {
+            "name": {
+                "type": "String",
+                "example": "Dateline BINGO"
+            },
+            "link": {
+                "type": "String",
+                "example": "https://bingogrid.web.app/import?d=…"
+            }
+        }
+    },
+    "close": "Fermer",
+    "@close": {
+        "description": "Generic close button"
+    },
+    "shareSubject": "Carte de bingo",
+    "@shareSubject": {
+        "description": "Subject/title used by the system share sheet"
+    },
+    "importTitle": "Un ami vous a partagé une carte de bingo",
+    "@importTitle": {
+        "description": "Title of the import-card screen shown to the receiver"
+    },
+    "importBody": "L’ajouter à vos cartes pour jouer avec lui ?",
+    "@importBody": {
+        "description": "Body of the import-card screen"
+    },
+    "importConfirm": "Ajouter à mes cartes",
+    "@importConfirm": {
+        "description": "Confirm button on the import-card screen"
+    },
+    "importCancel": "Pas maintenant",
+    "@importCancel": {
+        "description": "Cancel button on the import-card screen"
+    },
+    "importCollisionToast": "You already had a card with this name, so I added it as \"{newName}\".",
+    "@importCollisionToast": {
+        "description": "Toast shown after silently renaming an imported card to avoid a collision",
+        "placeholders": {
+            "newName": {
+                "type": "String",
+                "example": "Dateline BINGO (2)"
+            }
+        }
+    },
+    "importBadLinkToast": "Sorry, this invite couldn't be opened. Ask your friend to send it again.",
+    "@importBadLinkToast": {
+        "description": "Toast shown when an invite link is malformed"
+    },
+    "importOutdatedAppToast": "Update the app to open this invite.",
+    "@importOutdatedAppToast": {
+        "description": "Toast shown when an invite payload uses a newer schema"
+    },
+    "toastInfo": "Info",
+    "@toastInfo": {
+        "description": "Title of an informational toast"
+    },
+    "toastSuccess": "Succès",
+    "@toastSuccess": {
+        "description": "Title of a success toast"
+    },
+    "toastError": "Erreur",
+    "@toastError": {
+        "description": "Title of an error toast"
+    },
+    "lastChangeNever": "Dernière modification : jamais",
+    "@lastChangeNever": {
+        "description": "Footer line shown when a card has never been edited"
+    },
+    "lastChange": "Dernière modification : {date} {time}",
+    "@lastChange": {
+        "description": "Footer line showing when the card was last edited",
+        "placeholders": {
+            "date": {
+                "type": "String",
+                "example": "5.5.2026"
+            },
+            "time": {
+                "type": "String",
+                "example": "14:30"
+            }
+        }
+    },
+    "screenshotCaptionPlaying": "Une app toute simple pour créer une grille de bingo.\n\nSans inscription, sans pub, entièrement gratuite.",
+    "@screenshotCaptionPlaying": {
+        "description": "Promotional caption for the screenshot showing a played bingo board"
+    },
+    "screenshotCaptionCreate": "Seulement deux écrans pour créer une grille de bingo.",
+    "@screenshotCaptionCreate": {
+        "description": "Promotional caption for the screenshot showing the new-board screen"
+    },
+    "screenshotCaptionLocked": "C’est tout.",
+    "@screenshotCaptionLocked": {
+        "description": "Promotional caption for the screenshot showing the locked board"
+    },
+    "screenshotBoardName": "Mariage de David",
+    "@screenshotBoardName": {
+        "description": "Sample bingo board name used in generated screenshots"
+    },
+    "screenshotTilePhoneDuringVows": "Téléphone pendant les vœux",
+    "@screenshotTilePhoneDuringVows": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileChampagneSpilled": "Champagne renversé",
+    "@screenshotTileChampagneSpilled": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileSpeechTears": "Larmes pendant le discours",
+    "@screenshotTileSpeechTears": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileDramaticEntrance": "Entrée théâtrale",
+    "@screenshotTileDramaticEntrance": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileKidsDanceFloor": "Les enfants envahissent la piste",
+    "@screenshotTileKidsDanceFloor": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileGuestToast": "Un invité porte un toast",
+    "@screenshotTileGuestToast": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileCrowdClapsEarly": "Applaudissements trop tôt",
+    "@screenshotTileCrowdClapsEarly": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileDjClassic": "Le DJ met un classique",
+    "@screenshotTileDjClassic": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileGroupPhotoChaos": "Chaos pour la photo de groupe",
+    "@screenshotTileGroupPhotoChaos": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    }
+}

--- a/lib/l10n/arb/app_ja.arb
+++ b/lib/l10n/arb/app_ja.arb
@@ -1,0 +1,637 @@
+{
+    "@@locale": "ja",
+    "newCardTitle": "新しいビンゴ表を作成",
+    "@newCardTitle": {
+        "description": "AppBar title of the new-card screen"
+    },
+    "editCardTitle": "ビンゴ表を編集",
+    "@editCardTitle": {
+        "description": "AppBar title of the edit-card screen"
+    },
+    "cardNameLabel": "ビンゴ表の名前 *",
+    "@cardNameLabel": {
+        "description": "Label of the card-name text field"
+    },
+    "cardNameHint": "ビンゴ表の名前を入力",
+    "@cardNameHint": {
+        "description": "Placeholder hint for the card-name text field"
+    },
+    "createCardButton": "ビンゴ表を作成",
+    "@createCardButton": {
+        "description": "Confirm button on the new-card screen"
+    },
+    "updateCardButton": "ビンゴ表を更新",
+    "@updateCardButton": {
+        "description": "Confirm button on the edit-card screen"
+    },
+    "newBoardPreMadeSectionTitle": "Your pre-made items",
+    "@newBoardPreMadeSectionTitle": {
+        "description": "Expandable section title for pre-made items on the new-board screen"
+    },
+    "newBoardPreMadeButton": "Start with pre-made items",
+    "@newBoardPreMadeButton": {
+        "description": "Button that opens pre-made item selection from the new-board screen"
+    },
+    "newBoardPreMadeChangeButton": "Change pre-made items",
+    "@newBoardPreMadeChangeButton": {
+        "description": "Button that reopens pre-made item selection after items have been applied"
+    },
+    "newBoardPreMadeClearButton": "Clear pre-made items",
+    "@newBoardPreMadeClearButton": {
+        "description": "Button that clears applied pre-made entries from the new-board form"
+    },
+    "newBoardPreMadeAppliedCount": "{count} pre-made entries applied",
+    "@newBoardPreMadeAppliedCount": {
+        "description": "Summary of how many pre-made entries are applied to the new-board form",
+        "placeholders": {
+            "count": {
+                "type": "int",
+                "example": "40"
+            }
+        }
+    },
+    "newBoardPreMadeFullSummary": "{used} will be drawn at random for this board.",
+    "@newBoardPreMadeFullSummary": {
+        "description": "Summary when applied pre-made entries can fill the new board",
+        "placeholders": {
+            "used": {
+                "type": "int",
+                "example": "25"
+            }
+        }
+    },
+    "newBoardPreMadePartialSummary": "{used} cells will be filled. {blank} will stay blank.",
+    "@newBoardPreMadePartialSummary": {
+        "description": "Summary when applied pre-made entries are fewer than the board cells",
+        "placeholders": {
+            "used": {
+                "type": "int",
+                "example": "10"
+            },
+            "blank": {
+                "type": "int",
+                "example": "15"
+            }
+        }
+    },
+    "defaultCardName": "ビンゴカード",
+    "@defaultCardName": {
+        "description": "Fallback title shown when a card has no name"
+    },
+    "toggleHint": "長押しでマスをチェック",
+    "@toggleHint": {
+        "description": "Hint banner above the bingo grid"
+    },
+    "editingHintBefore": "Press the lock icon",
+    "@editingHintBefore": {
+        "description": "First half of the hint that explains the lock toggle. The lock icon is rendered between the two halves."
+    },
+    "editingHintAfter": " to make the fields not editable anymore.",
+    "@editingHintAfter": {
+        "description": "Second half of the lock-toggle hint, rendered after the lock icon."
+    },
+    "deleteCardTitle": "Delete Card",
+    "@deleteCardTitle": {
+        "description": "Title of the delete-card confirmation dialog"
+    },
+    "deleteCardConfirm": "Are you sure you want to delete this card?",
+    "@deleteCardConfirm": {
+        "description": "Body of the delete-card confirmation dialog"
+    },
+    "cancel": "キャンセル",
+    "@cancel": {
+        "description": "Generic cancel button"
+    },
+    "delete": "削除",
+    "@delete": {
+        "description": "Generic delete button"
+    },
+    "shuffleCardTitle": "Shuffle Card",
+    "@shuffleCardTitle": {
+        "description": "Title of the shuffle confirmation dialog"
+    },
+    "shuffleCardConfirm": "Are you sure you want to shuffle this card? All fields will be unchecked, after shuffling.",
+    "@shuffleCardConfirm": {
+        "description": "Body of the shuffle confirmation dialog"
+    },
+    "shuffle": "シャッフル",
+    "@shuffle": {
+        "description": "Confirm button to shuffle the card"
+    },
+    "ratingPromptTitle": "Do you like Custom Bingo?",
+    "@ratingPromptTitle": {
+        "description": "Title of the dialog shown before asking for an app store review"
+    },
+    "ratingPromptBody": "If so, a quick store review helps others find it.",
+    "@ratingPromptBody": {
+        "description": "Body of the dialog shown before asking for an app store review"
+    },
+    "ratingPromptNo": "Not really",
+    "@ratingPromptNo": {
+        "description": "Dismiss button for the rating prompt dialog"
+    },
+    "ratingPromptYes": "Yes, I like it",
+    "@ratingPromptYes": {
+        "description": "Confirm button that continues to the native app store review flow"
+    },
+    "boardActionShare": "共有",
+    "@boardActionShare": {
+        "description": "Menu item that opens the share dialog from the board action bar"
+    },
+    "boardActionEditBoard": "ボードを編集",
+    "@boardActionEditBoard": {
+        "description": "Menu item that opens the board edit flow from the board action bar"
+    },
+    "boardActionAddPreMadeItems": "Add pre-made items",
+    "@boardActionAddPreMadeItems": {
+        "description": "Debug menu item placeholder for filling a board with pre-made items"
+    },
+    "cellHint": "テキストを入力…",
+    "@cellHint": {
+        "description": "Placeholder for an empty bingo cell"
+    },
+    "edit": "編集",
+    "@edit": {
+        "description": "Edit menu item in a cell's context menu"
+    },
+    "markDone": "Mark Done",
+    "@markDone": {
+        "description": "Cell context menu item: mark this cell as done"
+    },
+    "markNotDone": "Mark Not Done",
+    "@markNotDone": {
+        "description": "Cell context menu item: clear the done state"
+    },
+    "newCardMenuItem": "新しいビンゴボード",
+    "@newCardMenuItem": {
+        "description": "Menu item that opens the new-card screen"
+    },
+    "yourCardsHeader": "あなたのボード",
+    "@yourCardsHeader": {
+        "description": "Section header in the popup menu listing saved cards"
+    },
+    "settingsHeader": "設定",
+    "@settingsHeader": {
+        "description": "Section header in the popup menu"
+    },
+    "appearanceMenuItem": "Appearance",
+    "@appearanceMenuItem": {
+        "description": "Menu item that opens the appearance settings screen"
+    },
+    "settingsAppearanceSection": "外観",
+    "@settingsAppearanceSection": {
+        "description": "Section title for appearance settings"
+    },
+    "settingsPreferencesSection": "環境設定",
+    "@settingsPreferencesSection": {
+        "description": "Section title for general preference settings"
+    },
+    "settingsBoardsSection": "ボード",
+    "@settingsBoardsSection": {
+        "description": "Section title for board-related settings"
+    },
+    "settingsHelpSection": "その他",
+    "@settingsHelpSection": {
+        "description": "Section title for additional settings, help, and support entries"
+    },
+    "settingsSupportSection": "サポート",
+    "@settingsSupportSection": {
+        "description": "Section title for supporting the developer"
+    },
+    "themeColorLabel": "テーマカラー",
+    "@themeColorLabel": {
+        "description": "Label above the theme color selector in settings"
+    },
+    "themeColorSettingsDescription": "アプリ全体で使う配色を選びます。",
+    "@themeColorSettingsDescription": {
+        "description": "Settings helper text for the theme color selector"
+    },
+    "languageSettingsTitle": "言語",
+    "@languageSettingsTitle": {
+        "description": "Settings tile title for choosing the app language"
+    },
+    "languageSettingsSelectorLabel": "アプリの言語",
+    "@languageSettingsSelectorLabel": {
+        "description": "Label above the language dropdown in settings"
+    },
+    "languageSettingsSystemOption": "システム標準（{language}）",
+    "@languageSettingsSystemOption": {
+        "description": "Dropdown option that makes the app follow the phone/system language. The placeholder is the current phone language display name.",
+        "placeholders": {
+            "language": {
+                "type": "String",
+                "example": "Deutsch"
+            }
+        }
+    },
+    "languageSettingsSystemDescription": "端末の言語に合わせます：{language}。",
+    "@languageSettingsSystemDescription": {
+        "description": "Settings helper text when no manual app language override is selected. The placeholder is the current phone language display name.",
+        "placeholders": {
+            "language": {
+                "type": "String",
+                "example": "Deutsch"
+            }
+        }
+    },
+    "languageSettingsOverrideDescription": "端末の言語ではなく、この言語を使います。",
+    "@languageSettingsOverrideDescription": {
+        "description": "Settings helper text when a manual app language override is selected"
+    },
+    "darkModeLabel": "ダークモード",
+    "@darkModeLabel": {
+        "description": "Label for the dark mode switch in settings"
+    },
+    "darkModeSettingsDescription": "暗めの画面表示を使います。",
+    "@darkModeSettingsDescription": {
+        "description": "Settings helper text for the dark mode switch"
+    },
+    "enableConfettiLabel": "紙吹雪",
+    "@enableConfettiLabel": {
+        "description": "Label for the confetti preference switch"
+    },
+    "enableConfettiSettingsDescription": "ビンゴ達成時にお祝いを表示します。",
+    "@enableConfettiSettingsDescription": {
+        "description": "Settings helper text for the confetti preference switch"
+    },
+    "preMadeTilesTitle": "Pre-made tiles",
+    "@preMadeTilesTitle": {
+        "description": "Title of the pre-made tiles settings screen and menu entry"
+    },
+    "preMadeTilesSettingsDescription": "Create reusable tile text for future boards.",
+    "@preMadeTilesSettingsDescription": {
+        "description": "Settings entry helper text for pre-made tiles"
+    },
+    "preMadeTilesDescription": "Create reusable bingo entries here. When you create a new board, you can add them without typing everything again.",
+    "@preMadeTilesDescription": {
+        "description": "Description shown below the pre-made tiles screen title"
+    },
+    "preMadeTilesSelectMode": "Select",
+    "@preMadeTilesSelectMode": {
+        "description": "Segmented control label for selecting pre-made tiles"
+    },
+    "preMadeTilesEditMode": "Edit",
+    "@preMadeTilesEditMode": {
+        "description": "Segmented control label for editing pre-made tiles"
+    },
+    "preMadeTileHint": "Tile text",
+    "@preMadeTileHint": {
+        "description": "Placeholder for a pre-made tile text field"
+    },
+    "preMadeTilesAdd": "Add tile",
+    "@preMadeTilesAdd": {
+        "description": "Accessible label and tooltip for adding a pre-made tile"
+    },
+    "preMadeTilesDelete": "Delete tile",
+    "@preMadeTilesDelete": {
+        "description": "Accessible label and tooltip for deleting a pre-made tile"
+    },
+    "preMadeTilesSelectAll": "Un/select all",
+    "@preMadeTilesSelectAll": {
+        "description": "Checkbox label for toggling all pre-made tile selections"
+    },
+    "preMadeTilesSelectNone": "Select none",
+    "@preMadeTilesSelectNone": {
+        "description": "Button label for clearing all selected pre-made tiles"
+    },
+    "preMadeTilesApply": "Apply",
+    "@preMadeTilesApply": {
+        "description": "Button label for applying selected pre-made tiles to a board"
+    },
+    "preMadeTilesReplaceItems": "Replace items",
+    "@preMadeTilesReplaceItems": {
+        "description": "Button label for replacing current board items with selected pre-made items"
+    },
+    "preMadeTilesFillItems": "Fill items",
+    "@preMadeTilesFillItems": {
+        "description": "Button label for filling empty board items with selected pre-made items"
+    },
+    "preMadeTilesBoardActionHelp": "Replace swaps the board entries with a random draw from your selection. Fill only adds items to empty tiles. On odd boards, the center tile stays in place.",
+    "@preMadeTilesBoardActionHelp": {
+        "description": "Helper text explaining replace and fill actions for pre-made items on an existing board"
+    },
+    "preMadeTilesSelectedCount": "{selected} / {total} selected",
+    "@preMadeTilesSelectedCount": {
+        "description": "Count of selected pre-made tiles",
+        "placeholders": {
+            "selected": {
+                "type": "int",
+                "example": "12"
+            },
+            "total": {
+                "type": "int",
+                "example": "24"
+            }
+        }
+    },
+    "preMadeTilesEmptyTitle": "No tiles yet",
+    "@preMadeTilesEmptyTitle": {
+        "description": "Empty-state title for the pre-made tiles screen"
+    },
+    "preMadeTilesEmptyBody": "Add a tile to start building a reusable list.",
+    "@preMadeTilesEmptyBody": {
+        "description": "Empty-state helper text for the pre-made tiles screen"
+    },
+    "proposeFeatures": "Propose Features",
+    "@proposeFeatures": {
+        "description": "Menu item that opens the UserOrient feedback board"
+    },
+    "proposeFeaturesSettingsDescription": "Vote on ideas and suggest what to build next.",
+    "@proposeFeaturesSettingsDescription": {
+        "description": "Settings helper text for the feature request entry"
+    },
+    "supportMeDirectly": "Support the developer",
+    "@supportMeDirectly": {
+        "description": "Menu item that opens the direct-support paywall"
+    },
+    "supportMeDirectlySettingsDescription": "Help fund development and keep the app improving.",
+    "@supportMeDirectlySettingsDescription": {
+        "description": "Settings helper text for the direct support entry"
+    },
+    "supportCarouselProTitle": "Support Custom Bingo",
+    "@supportCarouselProTitle": {
+        "description": "Title of the home-screen support carousel item that opens the paywall"
+    },
+    "supportCarouselProSubtitle": "Unlock bonus colors and help keep the app independent.",
+    "@supportCarouselProSubtitle": {
+        "description": "Subtitle of the home-screen support carousel item that opens the paywall"
+    },
+    "supportCarouselRateTitle": "Enjoying the app?",
+    "@supportCarouselRateTitle": {
+        "description": "Title of the home-screen support carousel item that asks for a store review"
+    },
+    "supportCarouselRateSubtitle": "A quick review helps more people find Custom Bingo.",
+    "@supportCarouselRateSubtitle": {
+        "description": "Subtitle of the home-screen support carousel item that asks for a store review"
+    },
+    "rateTheApp": "Rate the app",
+    "@rateTheApp": {
+        "description": "Settings entry that opens the native store rating dialog"
+    },
+    "rateTheAppSettingsDescription": "Open the store rating prompt.",
+    "@rateTheAppSettingsDescription": {
+        "description": "Settings helper text for the app rating entry"
+    },
+    "contactMe": "Contact me",
+    "@contactMe": {
+        "description": "Settings entry that opens an email composer"
+    },
+    "contactMeSettingsDescription": "Send feedback, questions, or bug reports by email.",
+    "@contactMeSettingsDescription": {
+        "description": "Settings helper text for the contact email entry"
+    },
+    "paywallTitle": "Support Custom Bingo",
+    "@paywallTitle": {
+        "description": "AppBar title of the direct-support paywall"
+    },
+    "paywallThankYouTitle": "Thank you",
+    "@paywallThankYouTitle": {
+        "description": "Paywall title shown after Pro access is active"
+    },
+    "paywallSupportTitle": "Support Custom Bingo",
+    "@paywallSupportTitle": {
+        "description": "Main title on the direct-support paywall"
+    },
+    "paywallSupportBody": "This purchase supports me, the developer, directly. You get my gratitude and a few small bonus things for your boards.",
+    "@paywallSupportBody": {
+        "description": "Main body copy on the direct-support paywall"
+    },
+    "paywallBonusGratitude": "My gratitude, sincerely.",
+    "@paywallBonusGratitude": {
+        "description": "First benefit line on the direct-support paywall"
+    },
+    "paywallBonusColors": "A few extra board colors.",
+    "@paywallBonusColors": {
+        "description": "Second benefit line on the direct-support paywall"
+    },
+    "paywallBonusExtras": "Small supporter extras over time.",
+    "@paywallBonusExtras": {
+        "description": "Third benefit line on the direct-support paywall"
+    },
+    "paywallFreeForever": "No one ever needs to pay for this app. Custom Bingo stays usable for everyone.",
+    "@paywallFreeForever": {
+        "description": "Footer reassurance on the direct-support paywall"
+    },
+    "paywallLoadingPrice": "Loading price",
+    "@paywallLoadingPrice": {
+        "description": "Placeholder shown while the paywall price is loading"
+    },
+    "paywallUnavailable": "Unavailable",
+    "@paywallUnavailable": {
+        "description": "Paywall price/button text when purchases are unavailable"
+    },
+    "paywallSupportOnce": "Support once",
+    "@paywallSupportOnce": {
+        "description": "Purchase button label on the direct-support paywall"
+    },
+    "paywallRestorePurchase": "Restore purchase",
+    "@paywallRestorePurchase": {
+        "description": "Restore button label on the direct-support paywall"
+    },
+    "paywallProActiveToast": "Custom Bingo Pro is active.",
+    "@paywallProActiveToast": {
+        "description": "Toast shown after a successful Pro purchase"
+    },
+    "paywallPurchaseInactiveToast": "Purchase finished, but Pro is not active.",
+    "@paywallPurchaseInactiveToast": {
+        "description": "Toast shown if a purchase returns without Pro access"
+    },
+    "paywallProRestoredToast": "Custom Bingo Pro restored.",
+    "@paywallProRestoredToast": {
+        "description": "Toast shown after restoring Pro access"
+    },
+    "paywallNoPurchaseFoundToast": "No Pro purchase found.",
+    "@paywallNoPurchaseFoundToast": {
+        "description": "Toast shown when restore finds no Pro access"
+    },
+    "paywallPurchasesUnavailable": "Purchases are unavailable right now.",
+    "@paywallPurchasesUnavailable": {
+        "description": "Fallback error text for a paywall purchase error"
+    },
+    "paywallPlatformUnavailable": "Purchases are unavailable on this platform.",
+    "@paywallPlatformUnavailable": {
+        "description": "Fallback paywall text when purchases are not configured for the platform"
+    },
+    "paywallCouldNotLoad": "Could not load purchase information.",
+    "@paywallCouldNotLoad": {
+        "description": "Fallback paywall error text for an unknown purchase loading error"
+    },
+    "shareTitle": "ビンゴカードを共有",
+    "@shareTitle": {
+        "description": "Title of the share dialog"
+    },
+    "shareDialogPrompt": "How would you like to share?",
+    "@shareDialogPrompt": {
+        "description": "Section header above the two share options"
+    },
+    "shareImageOptionTitle": "画像として共有",
+    "@shareImageOptionTitle": {
+        "description": "Title of the image-share option in the share dialog"
+    },
+    "shareImageOptionHelper": "Send a picture of your card. Anyone can see it — even without the app.",
+    "@shareImageOptionHelper": {
+        "description": "Helper text explaining what 'Share as image' does"
+    },
+    "shareImageOptionButton": "画像を共有",
+    "@shareImageOptionButton": {
+        "description": "Confirm button on the image-share option"
+    },
+    "shareInviteOptionTitle": "友だちを招待して遊ぶ",
+    "@shareInviteOptionTitle": {
+        "description": "Title of the play-together invite option"
+    },
+    "shareInviteOptionHelper": "Send this link to your friends who also have this app installed. They get the same card and you can play together.",
+    "@shareInviteOptionHelper": {
+        "description": "Helper text explaining what the invite link does"
+    },
+    "shareInviteIncludeMarks": "Include my checkmarks",
+    "@shareInviteIncludeMarks": {
+        "description": "Toggle label: include the sender's marks in the invite"
+    },
+    "shareInviteIncludeMarksHelper": "When on, your friends will see what you've already crossed off.",
+    "@shareInviteIncludeMarksHelper": {
+        "description": "Helper text under the include-checkmarks toggle"
+    },
+    "shareInviteOptionButton": "招待を送信",
+    "@shareInviteOptionButton": {
+        "description": "Confirm button on the invite-link option"
+    },
+    "shareInviteText": "「{name}」を一緒に遊ぼう！アプリで開いてください：\n{link}",
+    "@shareInviteText": {
+        "description": "Body text passed to the system share sheet alongside the invite link",
+        "placeholders": {
+            "name": {
+                "type": "String",
+                "example": "Dateline BINGO"
+            },
+            "link": {
+                "type": "String",
+                "example": "https://bingogrid.web.app/import?d=…"
+            }
+        }
+    },
+    "close": "閉じる",
+    "@close": {
+        "description": "Generic close button"
+    },
+    "shareSubject": "Bingo Card",
+    "@shareSubject": {
+        "description": "Subject/title used by the system share sheet"
+    },
+    "importTitle": "A friend shared a bingo card with you",
+    "@importTitle": {
+        "description": "Title of the import-card screen shown to the receiver"
+    },
+    "importBody": "Add it to your cards so you can play along?",
+    "@importBody": {
+        "description": "Body of the import-card screen"
+    },
+    "importConfirm": "自分のカードに追加",
+    "@importConfirm": {
+        "description": "Confirm button on the import-card screen"
+    },
+    "importCancel": "今はしない",
+    "@importCancel": {
+        "description": "Cancel button on the import-card screen"
+    },
+    "importCollisionToast": "You already had a card with this name, so I added it as \"{newName}\".",
+    "@importCollisionToast": {
+        "description": "Toast shown after silently renaming an imported card to avoid a collision",
+        "placeholders": {
+            "newName": {
+                "type": "String",
+                "example": "Dateline BINGO (2)"
+            }
+        }
+    },
+    "importBadLinkToast": "Sorry, this invite couldn't be opened. Ask your friend to send it again.",
+    "@importBadLinkToast": {
+        "description": "Toast shown when an invite link is malformed"
+    },
+    "importOutdatedAppToast": "Update the app to open this invite.",
+    "@importOutdatedAppToast": {
+        "description": "Toast shown when an invite payload uses a newer schema"
+    },
+    "toastInfo": "情報",
+    "@toastInfo": {
+        "description": "Title of an informational toast"
+    },
+    "toastSuccess": "成功",
+    "@toastSuccess": {
+        "description": "Title of a success toast"
+    },
+    "toastError": "エラー",
+    "@toastError": {
+        "description": "Title of an error toast"
+    },
+    "lastChangeNever": "最終変更：なし",
+    "@lastChangeNever": {
+        "description": "Footer line shown when a card has never been edited"
+    },
+    "lastChange": "最終変更：{date} {time}",
+    "@lastChange": {
+        "description": "Footer line showing when the card was last edited",
+        "placeholders": {
+            "date": {
+                "type": "String",
+                "example": "5.5.2026"
+            },
+            "time": {
+                "type": "String",
+                "example": "14:30"
+            }
+        }
+    },
+    "screenshotCaptionPlaying": "Just a simple app to create bingo board.\n\nNo signup, no ads, fully free to use.",
+    "@screenshotCaptionPlaying": {
+        "description": "Promotional caption for the screenshot showing a played bingo board"
+    },
+    "screenshotCaptionCreate": "Literally just 2 screens to create a bingo grid.",
+    "@screenshotCaptionCreate": {
+        "description": "Promotional caption for the screenshot showing the new-board screen"
+    },
+    "screenshotCaptionLocked": "That's it.",
+    "@screenshotCaptionLocked": {
+        "description": "Promotional caption for the screenshot showing the locked board"
+    },
+    "screenshotBoardName": "David's Wedding",
+    "@screenshotBoardName": {
+        "description": "Sample bingo board name used in generated screenshots"
+    },
+    "screenshotTilePhoneDuringVows": "Phone during vows",
+    "@screenshotTilePhoneDuringVows": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileChampagneSpilled": "Champagne spilled",
+    "@screenshotTileChampagneSpilled": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileSpeechTears": "Speech tears",
+    "@screenshotTileSpeechTears": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileDramaticEntrance": "Dramatic entrance",
+    "@screenshotTileDramaticEntrance": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileKidsDanceFloor": "Kids take the dance floor",
+    "@screenshotTileKidsDanceFloor": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileGuestToast": "Guest gives a toast",
+    "@screenshotTileGuestToast": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileCrowdClapsEarly": "Crowd claps early",
+    "@screenshotTileCrowdClapsEarly": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileDjClassic": "DJ plays a classic",
+    "@screenshotTileDjClassic": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileGroupPhotoChaos": "Group photo chaos",
+    "@screenshotTileGroupPhotoChaos": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    }
+}

--- a/lib/l10n/arb/app_ja.arb
+++ b/lib/l10n/arb/app_ja.arb
@@ -24,23 +24,23 @@
     "@updateCardButton": {
         "description": "Confirm button on the edit-card screen"
     },
-    "newBoardPreMadeSectionTitle": "Your pre-made items",
+    "newBoardPreMadeSectionTitle": "作成済み項目",
     "@newBoardPreMadeSectionTitle": {
         "description": "Expandable section title for pre-made items on the new-board screen"
     },
-    "newBoardPreMadeButton": "Start with pre-made items",
+    "newBoardPreMadeButton": "作成済み項目から始める",
     "@newBoardPreMadeButton": {
         "description": "Button that opens pre-made item selection from the new-board screen"
     },
-    "newBoardPreMadeChangeButton": "Change pre-made items",
+    "newBoardPreMadeChangeButton": "作成済み項目を変更",
     "@newBoardPreMadeChangeButton": {
         "description": "Button that reopens pre-made item selection after items have been applied"
     },
-    "newBoardPreMadeClearButton": "Clear pre-made items",
+    "newBoardPreMadeClearButton": "作成済み項目をクリア",
     "@newBoardPreMadeClearButton": {
         "description": "Button that clears applied pre-made entries from the new-board form"
     },
-    "newBoardPreMadeAppliedCount": "{count} pre-made entries applied",
+    "newBoardPreMadeAppliedCount": "{count} 件の作成済み項目を適用しました",
     "@newBoardPreMadeAppliedCount": {
         "description": "Summary of how many pre-made entries are applied to the new-board form",
         "placeholders": {
@@ -50,7 +50,7 @@
             }
         }
     },
-    "newBoardPreMadeFullSummary": "{used} will be drawn at random for this board.",
+    "newBoardPreMadeFullSummary": "このボードには {used} 件がランダムに選ばれます。",
     "@newBoardPreMadeFullSummary": {
         "description": "Summary when applied pre-made entries can fill the new board",
         "placeholders": {
@@ -60,7 +60,7 @@
             }
         }
     },
-    "newBoardPreMadePartialSummary": "{used} cells will be filled. {blank} will stay blank.",
+    "newBoardPreMadePartialSummary": "{used} マスが埋まります。{blank} マスは空のままです。",
     "@newBoardPreMadePartialSummary": {
         "description": "Summary when applied pre-made entries are fewer than the board cells",
         "placeholders": {
@@ -82,19 +82,19 @@
     "@toggleHint": {
         "description": "Hint banner above the bingo grid"
     },
-    "editingHintBefore": "Press the lock icon",
+    "editingHintBefore": "ロックアイコンを押すと",
     "@editingHintBefore": {
         "description": "First half of the hint that explains the lock toggle. The lock icon is rendered between the two halves."
     },
-    "editingHintAfter": " to make the fields not editable anymore.",
+    "editingHintAfter": "、マスを編集できないようにできます。",
     "@editingHintAfter": {
         "description": "Second half of the lock-toggle hint, rendered after the lock icon."
     },
-    "deleteCardTitle": "Delete Card",
+    "deleteCardTitle": "カードを削除",
     "@deleteCardTitle": {
         "description": "Title of the delete-card confirmation dialog"
     },
-    "deleteCardConfirm": "Are you sure you want to delete this card?",
+    "deleteCardConfirm": "このカードを削除してもよろしいですか？",
     "@deleteCardConfirm": {
         "description": "Body of the delete-card confirmation dialog"
     },
@@ -106,11 +106,11 @@
     "@delete": {
         "description": "Generic delete button"
     },
-    "shuffleCardTitle": "Shuffle Card",
+    "shuffleCardTitle": "カードをシャッフル",
     "@shuffleCardTitle": {
         "description": "Title of the shuffle confirmation dialog"
     },
-    "shuffleCardConfirm": "Are you sure you want to shuffle this card? All fields will be unchecked, after shuffling.",
+    "shuffleCardConfirm": "このカードをシャッフルしてもよろしいですか？シャッフル後、すべてのマスのチェックが外れます。",
     "@shuffleCardConfirm": {
         "description": "Body of the shuffle confirmation dialog"
     },
@@ -118,19 +118,19 @@
     "@shuffle": {
         "description": "Confirm button to shuffle the card"
     },
-    "ratingPromptTitle": "Do you like Custom Bingo?",
+    "ratingPromptTitle": "Custom Bingo は気に入りましたか？",
     "@ratingPromptTitle": {
         "description": "Title of the dialog shown before asking for an app store review"
     },
-    "ratingPromptBody": "If so, a quick store review helps others find it.",
+    "ratingPromptBody": "よろしければ、ストアでの短いレビューが他の人の発見につながります。",
     "@ratingPromptBody": {
         "description": "Body of the dialog shown before asking for an app store review"
     },
-    "ratingPromptNo": "Not really",
+    "ratingPromptNo": "あまり",
     "@ratingPromptNo": {
         "description": "Dismiss button for the rating prompt dialog"
     },
-    "ratingPromptYes": "Yes, I like it",
+    "ratingPromptYes": "はい、気に入りました",
     "@ratingPromptYes": {
         "description": "Confirm button that continues to the native app store review flow"
     },
@@ -142,7 +142,7 @@
     "@boardActionEditBoard": {
         "description": "Menu item that opens the board edit flow from the board action bar"
     },
-    "boardActionAddPreMadeItems": "Add pre-made items",
+    "boardActionAddPreMadeItems": "作成済み項目を追加",
     "@boardActionAddPreMadeItems": {
         "description": "Debug menu item placeholder for filling a board with pre-made items"
     },
@@ -154,11 +154,11 @@
     "@edit": {
         "description": "Edit menu item in a cell's context menu"
     },
-    "markDone": "Mark Done",
+    "markDone": "完了にする",
     "@markDone": {
         "description": "Cell context menu item: mark this cell as done"
     },
-    "markNotDone": "Mark Not Done",
+    "markNotDone": "未完了にする",
     "@markNotDone": {
         "description": "Cell context menu item: clear the done state"
     },
@@ -166,15 +166,53 @@
     "@newCardMenuItem": {
         "description": "Menu item that opens the new-card screen"
     },
+    "allBoardsMenuItem": "すべてのボード",
+    "@allBoardsMenuItem": {
+        "description": "Menu item that opens the list of all saved boards"
+    },
     "yourCardsHeader": "あなたのボード",
     "@yourCardsHeader": {
         "description": "Section header in the popup menu listing saved cards"
+    },
+    "noBoardsYet": "ボードはまだありません",
+    "@noBoardsYet": {
+        "description": "Empty-state title shown when there are no saved boards"
+    },
+    "pageNotFoundTitle": "ページが見つかりません",
+    "@pageNotFoundTitle": {
+        "description": "Title shown on the fallback route when a page cannot be found"
+    },
+    "homeButton": "ホーム",
+    "@homeButton": {
+        "description": "Button that navigates back to the home screen"
+    },
+    "revenueCatUserIdLabel": "RevenueCat ユーザーID: {userId}",
+    "@revenueCatUserIdLabel": {
+        "description": "Debug settings label showing the RevenueCat user id",
+        "placeholders": {
+            "userId": {
+                "type": "String",
+                "example": "abc123"
+            }
+        }
+    },
+    "copyRevenueCatUserIdTooltip": "RevenueCat ユーザーIDをコピー",
+    "@copyRevenueCatUserIdTooltip": {
+        "description": "Tooltip for copying the RevenueCat user id from debug settings"
+    },
+    "revenueCatUserIdCopiedToast": "RevenueCat ユーザーIDをコピーしました。",
+    "@revenueCatUserIdCopiedToast": {
+        "description": "Toast shown after copying the RevenueCat user id"
     },
     "settingsHeader": "設定",
     "@settingsHeader": {
         "description": "Section header in the popup menu"
     },
-    "appearanceMenuItem": "Appearance",
+    "clearSettingsMenuItem": "設定をクリア",
+    "@clearSettingsMenuItem": {
+        "description": "Debug menu item that clears saved settings"
+    },
+    "appearanceMenuItem": "外観",
     "@appearanceMenuItem": {
         "description": "Menu item that opens the appearance settings screen"
     },
@@ -254,63 +292,63 @@
     "@enableConfettiSettingsDescription": {
         "description": "Settings helper text for the confetti preference switch"
     },
-    "preMadeTilesTitle": "Pre-made tiles",
+    "preMadeTilesTitle": "作成済みタイル",
     "@preMadeTilesTitle": {
         "description": "Title of the pre-made tiles settings screen and menu entry"
     },
-    "preMadeTilesSettingsDescription": "Create reusable tile text for future boards.",
+    "preMadeTilesSettingsDescription": "今後のボードで使えるタイル文を作成します。",
     "@preMadeTilesSettingsDescription": {
         "description": "Settings entry helper text for pre-made tiles"
     },
-    "preMadeTilesDescription": "Create reusable bingo entries here. When you create a new board, you can add them without typing everything again.",
+    "preMadeTilesDescription": "再利用できるビンゴ項目をここで作成します。新しいボードを作るとき、入力し直さずに追加できます。",
     "@preMadeTilesDescription": {
         "description": "Description shown below the pre-made tiles screen title"
     },
-    "preMadeTilesSelectMode": "Select",
+    "preMadeTilesSelectMode": "選択",
     "@preMadeTilesSelectMode": {
         "description": "Segmented control label for selecting pre-made tiles"
     },
-    "preMadeTilesEditMode": "Edit",
+    "preMadeTilesEditMode": "編集",
     "@preMadeTilesEditMode": {
         "description": "Segmented control label for editing pre-made tiles"
     },
-    "preMadeTileHint": "Tile text",
+    "preMadeTileHint": "タイルのテキスト",
     "@preMadeTileHint": {
         "description": "Placeholder for a pre-made tile text field"
     },
-    "preMadeTilesAdd": "Add tile",
+    "preMadeTilesAdd": "タイルを追加",
     "@preMadeTilesAdd": {
         "description": "Accessible label and tooltip for adding a pre-made tile"
     },
-    "preMadeTilesDelete": "Delete tile",
+    "preMadeTilesDelete": "タイルを削除",
     "@preMadeTilesDelete": {
         "description": "Accessible label and tooltip for deleting a pre-made tile"
     },
-    "preMadeTilesSelectAll": "Un/select all",
+    "preMadeTilesSelectAll": "すべて選択/解除",
     "@preMadeTilesSelectAll": {
         "description": "Checkbox label for toggling all pre-made tile selections"
     },
-    "preMadeTilesSelectNone": "Select none",
+    "preMadeTilesSelectNone": "選択を解除",
     "@preMadeTilesSelectNone": {
         "description": "Button label for clearing all selected pre-made tiles"
     },
-    "preMadeTilesApply": "Apply",
+    "preMadeTilesApply": "適用",
     "@preMadeTilesApply": {
         "description": "Button label for applying selected pre-made tiles to a board"
     },
-    "preMadeTilesReplaceItems": "Replace items",
+    "preMadeTilesReplaceItems": "項目を置き換え",
     "@preMadeTilesReplaceItems": {
         "description": "Button label for replacing current board items with selected pre-made items"
     },
-    "preMadeTilesFillItems": "Fill items",
+    "preMadeTilesFillItems": "項目を埋める",
     "@preMadeTilesFillItems": {
         "description": "Button label for filling empty board items with selected pre-made items"
     },
-    "preMadeTilesBoardActionHelp": "Replace swaps the board entries with a random draw from your selection. Fill only adds items to empty tiles. On odd boards, the center tile stays in place.",
+    "preMadeTilesBoardActionHelp": "置き換えは、選択内容からランダムに引いた項目でボードを入れ替えます。埋めるは空のタイルにだけ項目を追加します。奇数サイズのボードでは中央タイルはそのままです。",
     "@preMadeTilesBoardActionHelp": {
         "description": "Helper text explaining replace and fill actions for pre-made items on an existing board"
     },
-    "preMadeTilesSelectedCount": "{selected} / {total} selected",
+    "preMadeTilesSelectedCount": "{selected} / {total} 選択済み",
     "@preMadeTilesSelectedCount": {
         "description": "Count of selected pre-made tiles",
         "placeholders": {
@@ -324,135 +362,135 @@
             }
         }
     },
-    "preMadeTilesEmptyTitle": "No tiles yet",
+    "preMadeTilesEmptyTitle": "タイルはまだありません",
     "@preMadeTilesEmptyTitle": {
         "description": "Empty-state title for the pre-made tiles screen"
     },
-    "preMadeTilesEmptyBody": "Add a tile to start building a reusable list.",
+    "preMadeTilesEmptyBody": "タイルを追加して、再利用できるリストを作り始めましょう。",
     "@preMadeTilesEmptyBody": {
         "description": "Empty-state helper text for the pre-made tiles screen"
     },
-    "proposeFeatures": "Propose Features",
+    "proposeFeatures": "機能を提案",
     "@proposeFeatures": {
         "description": "Menu item that opens the UserOrient feedback board"
     },
-    "proposeFeaturesSettingsDescription": "Vote on ideas and suggest what to build next.",
+    "proposeFeaturesSettingsDescription": "アイデアに投票して、次に作るものを提案します。",
     "@proposeFeaturesSettingsDescription": {
         "description": "Settings helper text for the feature request entry"
     },
-    "supportMeDirectly": "Support the developer",
+    "supportMeDirectly": "開発者を支援",
     "@supportMeDirectly": {
         "description": "Menu item that opens the direct-support paywall"
     },
-    "supportMeDirectlySettingsDescription": "Help fund development and keep the app improving.",
+    "supportMeDirectlySettingsDescription": "開発資金を支援し、アプリの改善を続けられるようにします。",
     "@supportMeDirectlySettingsDescription": {
         "description": "Settings helper text for the direct support entry"
     },
-    "supportCarouselProTitle": "Support Custom Bingo",
+    "supportCarouselProTitle": "Custom Bingo を支援",
     "@supportCarouselProTitle": {
         "description": "Title of the home-screen support carousel item that opens the paywall"
     },
-    "supportCarouselProSubtitle": "Unlock bonus colors and help keep the app independent.",
+    "supportCarouselProSubtitle": "追加カラーを解除し、アプリの独立運営を支援します。",
     "@supportCarouselProSubtitle": {
         "description": "Subtitle of the home-screen support carousel item that opens the paywall"
     },
-    "supportCarouselRateTitle": "Enjoying the app?",
+    "supportCarouselRateTitle": "アプリを楽しんでいますか？",
     "@supportCarouselRateTitle": {
         "description": "Title of the home-screen support carousel item that asks for a store review"
     },
-    "supportCarouselRateSubtitle": "A quick review helps more people find Custom Bingo.",
+    "supportCarouselRateSubtitle": "短いレビューが、より多くの人に Custom Bingo を見つけてもらう助けになります。",
     "@supportCarouselRateSubtitle": {
         "description": "Subtitle of the home-screen support carousel item that asks for a store review"
     },
-    "rateTheApp": "Rate the app",
+    "rateTheApp": "アプリを評価",
     "@rateTheApp": {
         "description": "Settings entry that opens the native store rating dialog"
     },
-    "rateTheAppSettingsDescription": "Open the store rating prompt.",
+    "rateTheAppSettingsDescription": "ストア評価の案内を開きます。",
     "@rateTheAppSettingsDescription": {
         "description": "Settings helper text for the app rating entry"
     },
-    "contactMe": "Contact me",
+    "contactMe": "問い合わせる",
     "@contactMe": {
         "description": "Settings entry that opens an email composer"
     },
-    "contactMeSettingsDescription": "Send feedback, questions, or bug reports by email.",
+    "contactMeSettingsDescription": "感想、質問、不具合報告をメールで送ります。",
     "@contactMeSettingsDescription": {
         "description": "Settings helper text for the contact email entry"
     },
-    "paywallTitle": "Support Custom Bingo",
+    "paywallTitle": "Custom Bingo を支援",
     "@paywallTitle": {
         "description": "AppBar title of the direct-support paywall"
     },
-    "paywallThankYouTitle": "Thank you",
+    "paywallThankYouTitle": "ありがとうございます",
     "@paywallThankYouTitle": {
         "description": "Paywall title shown after Pro access is active"
     },
-    "paywallSupportTitle": "Support Custom Bingo",
+    "paywallSupportTitle": "Custom Bingo を支援",
     "@paywallSupportTitle": {
         "description": "Main title on the direct-support paywall"
     },
-    "paywallSupportBody": "This purchase supports me, the developer, directly. You get my gratitude and a few small bonus things for your boards.",
+    "paywallSupportBody": "この購入は開発者である私を直接支援します。感謝の気持ちと、ボード用の小さな追加要素を受け取れます。",
     "@paywallSupportBody": {
         "description": "Main body copy on the direct-support paywall"
     },
-    "paywallBonusGratitude": "My gratitude, sincerely.",
+    "paywallBonusGratitude": "心からの感謝。",
     "@paywallBonusGratitude": {
         "description": "First benefit line on the direct-support paywall"
     },
-    "paywallBonusColors": "A few extra board colors.",
+    "paywallBonusColors": "ボード用の追加カラー。",
     "@paywallBonusColors": {
         "description": "Second benefit line on the direct-support paywall"
     },
-    "paywallBonusExtras": "Small supporter extras over time.",
+    "paywallBonusExtras": "支援者向けの小さな追加要素。",
     "@paywallBonusExtras": {
         "description": "Third benefit line on the direct-support paywall"
     },
-    "paywallFreeForever": "No one ever needs to pay for this app. Custom Bingo stays usable for everyone.",
+    "paywallFreeForever": "このアプリに支払いは必須ではありません。Custom Bingo は誰でも使い続けられます。",
     "@paywallFreeForever": {
         "description": "Footer reassurance on the direct-support paywall"
     },
-    "paywallLoadingPrice": "Loading price",
+    "paywallLoadingPrice": "価格を読み込み中",
     "@paywallLoadingPrice": {
         "description": "Placeholder shown while the paywall price is loading"
     },
-    "paywallUnavailable": "Unavailable",
+    "paywallUnavailable": "利用できません",
     "@paywallUnavailable": {
         "description": "Paywall price/button text when purchases are unavailable"
     },
-    "paywallSupportOnce": "Support once",
+    "paywallSupportOnce": "一度支援する",
     "@paywallSupportOnce": {
         "description": "Purchase button label on the direct-support paywall"
     },
-    "paywallRestorePurchase": "Restore purchase",
+    "paywallRestorePurchase": "購入を復元",
     "@paywallRestorePurchase": {
         "description": "Restore button label on the direct-support paywall"
     },
-    "paywallProActiveToast": "Custom Bingo Pro is active.",
+    "paywallProActiveToast": "Custom Bingo Pro が有効です。",
     "@paywallProActiveToast": {
         "description": "Toast shown after a successful Pro purchase"
     },
-    "paywallPurchaseInactiveToast": "Purchase finished, but Pro is not active.",
+    "paywallPurchaseInactiveToast": "購入は完了しましたが、Pro は有効ではありません。",
     "@paywallPurchaseInactiveToast": {
         "description": "Toast shown if a purchase returns without Pro access"
     },
-    "paywallProRestoredToast": "Custom Bingo Pro restored.",
+    "paywallProRestoredToast": "Custom Bingo Pro を復元しました。",
     "@paywallProRestoredToast": {
         "description": "Toast shown after restoring Pro access"
     },
-    "paywallNoPurchaseFoundToast": "No Pro purchase found.",
+    "paywallNoPurchaseFoundToast": "Pro の購入は見つかりませんでした。",
     "@paywallNoPurchaseFoundToast": {
         "description": "Toast shown when restore finds no Pro access"
     },
-    "paywallPurchasesUnavailable": "Purchases are unavailable right now.",
+    "paywallPurchasesUnavailable": "現在、購入は利用できません。",
     "@paywallPurchasesUnavailable": {
         "description": "Fallback error text for a paywall purchase error"
     },
-    "paywallPlatformUnavailable": "Purchases are unavailable on this platform.",
+    "paywallPlatformUnavailable": "このプラットフォームでは購入を利用できません。",
     "@paywallPlatformUnavailable": {
         "description": "Fallback paywall text when purchases are not configured for the platform"
     },
-    "paywallCouldNotLoad": "Could not load purchase information.",
+    "paywallCouldNotLoad": "購入情報を読み込めませんでした。",
     "@paywallCouldNotLoad": {
         "description": "Fallback paywall error text for an unknown purchase loading error"
     },
@@ -460,7 +498,7 @@
     "@shareTitle": {
         "description": "Title of the share dialog"
     },
-    "shareDialogPrompt": "How would you like to share?",
+    "shareDialogPrompt": "どのように共有しますか？",
     "@shareDialogPrompt": {
         "description": "Section header above the two share options"
     },
@@ -468,7 +506,7 @@
     "@shareImageOptionTitle": {
         "description": "Title of the image-share option in the share dialog"
     },
-    "shareImageOptionHelper": "Send a picture of your card. Anyone can see it — even without the app.",
+    "shareImageOptionHelper": "カードの画像を送ります。アプリがなくても誰でも見られます。",
     "@shareImageOptionHelper": {
         "description": "Helper text explaining what 'Share as image' does"
     },
@@ -480,15 +518,15 @@
     "@shareInviteOptionTitle": {
         "description": "Title of the play-together invite option"
     },
-    "shareInviteOptionHelper": "Send this link to your friends who also have this app installed. They get the same card and you can play together.",
+    "shareInviteOptionHelper": "このアプリをインストールしている友達にリンクを送ります。同じカードを受け取って一緒に遊べます。",
     "@shareInviteOptionHelper": {
         "description": "Helper text explaining what the invite link does"
     },
-    "shareInviteIncludeMarks": "Include my checkmarks",
+    "shareInviteIncludeMarks": "自分のチェックを含める",
     "@shareInviteIncludeMarks": {
         "description": "Toggle label: include the sender's marks in the invite"
     },
-    "shareInviteIncludeMarksHelper": "When on, your friends will see what you've already crossed off.",
+    "shareInviteIncludeMarksHelper": "オンにすると、友達はあなたがすでにチェックした項目を見られます。",
     "@shareInviteIncludeMarksHelper": {
         "description": "Helper text under the include-checkmarks toggle"
     },
@@ -514,15 +552,15 @@
     "@close": {
         "description": "Generic close button"
     },
-    "shareSubject": "Bingo Card",
+    "shareSubject": "ビンゴカード",
     "@shareSubject": {
         "description": "Subject/title used by the system share sheet"
     },
-    "importTitle": "A friend shared a bingo card with you",
+    "importTitle": "友達がビンゴカードを共有しました",
     "@importTitle": {
         "description": "Title of the import-card screen shown to the receiver"
     },
-    "importBody": "Add it to your cards so you can play along?",
+    "importBody": "一緒に遊ぶためにカードに追加しますか？",
     "@importBody": {
         "description": "Body of the import-card screen"
     },
@@ -534,7 +572,7 @@
     "@importCancel": {
         "description": "Cancel button on the import-card screen"
     },
-    "importCollisionToast": "You already had a card with this name, so I added it as \"{newName}\".",
+    "importCollisionToast": "同じ名前のカードが既にあったため、「{newName}」として追加しました。",
     "@importCollisionToast": {
         "description": "Toast shown after silently renaming an imported card to avoid a collision",
         "placeholders": {
@@ -544,11 +582,11 @@
             }
         }
     },
-    "importBadLinkToast": "Sorry, this invite couldn't be opened. Ask your friend to send it again.",
+    "importBadLinkToast": "この招待を開けませんでした。友達にもう一度送ってもらってください。",
     "@importBadLinkToast": {
         "description": "Toast shown when an invite link is malformed"
     },
-    "importOutdatedAppToast": "Update the app to open this invite.",
+    "importOutdatedAppToast": "この招待を開くにはアプリを更新してください。",
     "@importOutdatedAppToast": {
         "description": "Toast shown when an invite payload uses a newer schema"
     },
@@ -582,55 +620,55 @@
             }
         }
     },
-    "screenshotCaptionPlaying": "Just a simple app to create bingo board.\n\nNo signup, no ads, fully free to use.",
+    "screenshotCaptionPlaying": "ビンゴボードを作るためのシンプルなアプリ。\\n\\n登録なし、広告なし、完全無料。",
     "@screenshotCaptionPlaying": {
         "description": "Promotional caption for the screenshot showing a played bingo board"
     },
-    "screenshotCaptionCreate": "Literally just 2 screens to create a bingo grid.",
+    "screenshotCaptionCreate": "ビンゴグリッド作成はたった2画面。",
     "@screenshotCaptionCreate": {
         "description": "Promotional caption for the screenshot showing the new-board screen"
     },
-    "screenshotCaptionLocked": "That's it.",
+    "screenshotCaptionLocked": "これだけです。",
     "@screenshotCaptionLocked": {
         "description": "Promotional caption for the screenshot showing the locked board"
     },
-    "screenshotBoardName": "David's Wedding",
+    "screenshotBoardName": "デイビッドの結婚式",
     "@screenshotBoardName": {
         "description": "Sample bingo board name used in generated screenshots"
     },
-    "screenshotTilePhoneDuringVows": "Phone during vows",
+    "screenshotTilePhoneDuringVows": "誓いの最中に電話",
     "@screenshotTilePhoneDuringVows": {
         "description": "Sample bingo tile text used in generated screenshots"
     },
-    "screenshotTileChampagneSpilled": "Champagne spilled",
+    "screenshotTileChampagneSpilled": "シャンパンがこぼれる",
     "@screenshotTileChampagneSpilled": {
         "description": "Sample bingo tile text used in generated screenshots"
     },
-    "screenshotTileSpeechTears": "Speech tears",
+    "screenshotTileSpeechTears": "スピーチで涙",
     "@screenshotTileSpeechTears": {
         "description": "Sample bingo tile text used in generated screenshots"
     },
-    "screenshotTileDramaticEntrance": "Dramatic entrance",
+    "screenshotTileDramaticEntrance": "ドラマチックな入場",
     "@screenshotTileDramaticEntrance": {
         "description": "Sample bingo tile text used in generated screenshots"
     },
-    "screenshotTileKidsDanceFloor": "Kids take the dance floor",
+    "screenshotTileKidsDanceFloor": "子どもがダンスフロアへ",
     "@screenshotTileKidsDanceFloor": {
         "description": "Sample bingo tile text used in generated screenshots"
     },
-    "screenshotTileGuestToast": "Guest gives a toast",
+    "screenshotTileGuestToast": "ゲストが乾杯",
     "@screenshotTileGuestToast": {
         "description": "Sample bingo tile text used in generated screenshots"
     },
-    "screenshotTileCrowdClapsEarly": "Crowd claps early",
+    "screenshotTileCrowdClapsEarly": "拍手が早すぎる",
     "@screenshotTileCrowdClapsEarly": {
         "description": "Sample bingo tile text used in generated screenshots"
     },
-    "screenshotTileDjClassic": "DJ plays a classic",
+    "screenshotTileDjClassic": "DJが定番曲を流す",
     "@screenshotTileDjClassic": {
         "description": "Sample bingo tile text used in generated screenshots"
     },
-    "screenshotTileGroupPhotoChaos": "Group photo chaos",
+    "screenshotTileGroupPhotoChaos": "集合写真が大混乱",
     "@screenshotTileGroupPhotoChaos": {
         "description": "Sample bingo tile text used in generated screenshots"
     }

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -326,17 +326,65 @@ abstract class AppLocalizations {
   /// **'New bingo board'**
   String get newCardMenuItem;
 
+  /// Menu item that opens the list of all saved boards
+  ///
+  /// In en, this message translates to:
+  /// **'All boards'**
+  String get allBoardsMenuItem;
+
   /// Section header in the popup menu listing saved cards
   ///
   /// In en, this message translates to:
   /// **'Your Boards'**
   String get yourCardsHeader;
 
+  /// Empty-state title shown when there are no saved boards
+  ///
+  /// In en, this message translates to:
+  /// **'No boards yet'**
+  String get noBoardsYet;
+
+  /// Title shown on the fallback route when a page cannot be found
+  ///
+  /// In en, this message translates to:
+  /// **'Page Not Found'**
+  String get pageNotFoundTitle;
+
+  /// Button that navigates back to the home screen
+  ///
+  /// In en, this message translates to:
+  /// **'Home'**
+  String get homeButton;
+
+  /// Debug settings label showing the RevenueCat user id
+  ///
+  /// In en, this message translates to:
+  /// **'RevenueCat user id: {userId}'**
+  String revenueCatUserIdLabel(String userId);
+
+  /// Tooltip for copying the RevenueCat user id from debug settings
+  ///
+  /// In en, this message translates to:
+  /// **'Copy RevenueCat user id'**
+  String get copyRevenueCatUserIdTooltip;
+
+  /// Toast shown after copying the RevenueCat user id
+  ///
+  /// In en, this message translates to:
+  /// **'RevenueCat user id copied.'**
+  String get revenueCatUserIdCopiedToast;
+
   /// Section header in the popup menu
   ///
   /// In en, this message translates to:
   /// **'Settings'**
   String get settingsHeader;
+
+  /// Debug menu item that clears saved settings
+  ///
+  /// In en, this message translates to:
+  /// **'Clear Settings'**
+  String get clearSettingsMenuItem;
 
   /// Menu item that opens the appearance settings screen
   ///

--- a/lib/l10n/arb/app_localizations.dart
+++ b/lib/l10n/arb/app_localizations.dart
@@ -5,8 +5,14 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:intl/intl.dart' as intl;
 
+import 'app_localizations_ar.dart';
 import 'app_localizations_de.dart';
 import 'app_localizations_en.dart';
+import 'app_localizations_es.dart';
+import 'app_localizations_fr.dart';
+import 'app_localizations_ja.dart';
+import 'app_localizations_pt.dart';
+import 'app_localizations_zh.dart';
 
 // ignore_for_file: type=lint
 
@@ -94,8 +100,14 @@ abstract class AppLocalizations {
 
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
+    Locale('ar'),
     Locale('de'),
     Locale('en'),
+    Locale('es'),
+    Locale('fr'),
+    Locale('ja'),
+    Locale('pt'),
+    Locale('zh'),
   ];
 
   /// AppBar title of the new-card screen
@@ -373,6 +385,36 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Choose the palette used across the app.'**
   String get themeColorSettingsDescription;
+
+  /// Settings tile title for choosing the app language
+  ///
+  /// In en, this message translates to:
+  /// **'Language'**
+  String get languageSettingsTitle;
+
+  /// Label above the language dropdown in settings
+  ///
+  /// In en, this message translates to:
+  /// **'App language'**
+  String get languageSettingsSelectorLabel;
+
+  /// Dropdown option that makes the app follow the phone/system language. The placeholder is the current phone language display name.
+  ///
+  /// In en, this message translates to:
+  /// **'System default ({language})'**
+  String languageSettingsSystemOption(String language);
+
+  /// Settings helper text when no manual app language override is selected. The placeholder is the current phone language display name.
+  ///
+  /// In en, this message translates to:
+  /// **'Following your phone language: {language}.'**
+  String languageSettingsSystemDescription(String language);
+
+  /// Settings helper text when a manual app language override is selected
+  ///
+  /// In en, this message translates to:
+  /// **'Use this language instead of the phone language.'**
+  String get languageSettingsOverrideDescription;
 
   /// Label for the dark mode switch in settings
   ///
@@ -925,8 +967,16 @@ class _AppLocalizationsDelegate
   }
 
   @override
-  bool isSupported(Locale locale) =>
-      <String>['de', 'en'].contains(locale.languageCode);
+  bool isSupported(Locale locale) => <String>[
+    'ar',
+    'de',
+    'en',
+    'es',
+    'fr',
+    'ja',
+    'pt',
+    'zh',
+  ].contains(locale.languageCode);
 
   @override
   bool shouldReload(_AppLocalizationsDelegate old) => false;
@@ -935,10 +985,22 @@ class _AppLocalizationsDelegate
 AppLocalizations lookupAppLocalizations(Locale locale) {
   // Lookup logic when only language code is specified.
   switch (locale.languageCode) {
+    case 'ar':
+      return AppLocalizationsAr();
     case 'de':
       return AppLocalizationsDe();
     case 'en':
       return AppLocalizationsEn();
+    case 'es':
+      return AppLocalizationsEs();
+    case 'fr':
+      return AppLocalizationsFr();
+    case 'ja':
+      return AppLocalizationsJa();
+    case 'pt':
+      return AppLocalizationsPt();
+    case 'zh':
+      return AppLocalizationsZh();
   }
 
   throw FlutterError(

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -27,30 +27,30 @@ class AppLocalizationsAr extends AppLocalizations {
   String get updateCardButton => 'تحديث شبكة البنغو';
 
   @override
-  String get newBoardPreMadeSectionTitle => 'Your pre-made items';
+  String get newBoardPreMadeSectionTitle => 'عناصرك الجاهزة';
 
   @override
-  String get newBoardPreMadeButton => 'Start with pre-made items';
+  String get newBoardPreMadeButton => 'ابدأ بعناصر جاهزة';
 
   @override
-  String get newBoardPreMadeChangeButton => 'Change pre-made items';
+  String get newBoardPreMadeChangeButton => 'تغيير العناصر الجاهزة';
 
   @override
-  String get newBoardPreMadeClearButton => 'Clear pre-made items';
+  String get newBoardPreMadeClearButton => 'مسح العناصر الجاهزة';
 
   @override
   String newBoardPreMadeAppliedCount(int count) {
-    return '$count pre-made entries applied';
+    return 'تم تطبيق $count إدخالات جاهزة';
   }
 
   @override
   String newBoardPreMadeFullSummary(int used) {
-    return '$used will be drawn at random for this board.';
+    return 'سيتم اختيار $used عشوائيًا لهذا اللوح.';
   }
 
   @override
   String newBoardPreMadePartialSummary(int used, int blank) {
-    return '$used cells will be filled. $blank will stay blank.';
+    return 'سيتم ملء $used خانات. ستبقى $blank فارغة.';
   }
 
   @override
@@ -60,16 +60,16 @@ class AppLocalizationsAr extends AppLocalizations {
   String get toggleHint => 'اضغط مطولًا لوضع علامة على خانة';
 
   @override
-  String get editingHintBefore => 'Press the lock icon';
+  String get editingHintBefore => 'اضغط على أيقونة القفل';
 
   @override
-  String get editingHintAfter => ' to make the fields not editable anymore.';
+  String get editingHintAfter => ' لجعل الخانات غير قابلة للتحرير.';
 
   @override
-  String get deleteCardTitle => 'Delete Card';
+  String get deleteCardTitle => 'حذف البطاقة';
 
   @override
-  String get deleteCardConfirm => 'Are you sure you want to delete this card?';
+  String get deleteCardConfirm => 'هل أنت متأكد أنك تريد حذف هذه البطاقة؟';
 
   @override
   String get cancel => 'إلغاء';
@@ -78,27 +78,27 @@ class AppLocalizationsAr extends AppLocalizations {
   String get delete => 'حذف';
 
   @override
-  String get shuffleCardTitle => 'Shuffle Card';
+  String get shuffleCardTitle => 'خلط البطاقة';
 
   @override
   String get shuffleCardConfirm =>
-      'Are you sure you want to shuffle this card? All fields will be unchecked, after shuffling.';
+      'هل أنت متأكد أنك تريد خلط هذه البطاقة؟ سيتم إلغاء تحديد كل الخانات بعد الخلط.';
 
   @override
   String get shuffle => 'خلط';
 
   @override
-  String get ratingPromptTitle => 'Do you like Custom Bingo?';
+  String get ratingPromptTitle => 'هل يعجبك Custom Bingo؟';
 
   @override
   String get ratingPromptBody =>
-      'If so, a quick store review helps others find it.';
+      'إذا كان كذلك، فإن تقييمًا سريعًا في المتجر يساعد الآخرين على العثور عليه.';
 
   @override
-  String get ratingPromptNo => 'Not really';
+  String get ratingPromptNo => 'ليس كثيرًا';
 
   @override
-  String get ratingPromptYes => 'Yes, I like it';
+  String get ratingPromptYes => 'نعم، يعجبني';
 
   @override
   String get boardActionShare => 'مشاركة';
@@ -107,7 +107,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get boardActionEditBoard => 'تعديل اللوحة';
 
   @override
-  String get boardActionAddPreMadeItems => 'Add pre-made items';
+  String get boardActionAddPreMadeItems => 'إضافة عناصر جاهزة';
 
   @override
   String get cellHint => 'أدخل نصًا…';
@@ -116,22 +116,48 @@ class AppLocalizationsAr extends AppLocalizations {
   String get edit => 'تعديل';
 
   @override
-  String get markDone => 'Mark Done';
+  String get markDone => 'وضع علامة تم';
 
   @override
-  String get markNotDone => 'Mark Not Done';
+  String get markNotDone => 'إزالة علامة تم';
 
   @override
   String get newCardMenuItem => 'لوحة بنغو جديدة';
 
   @override
+  String get allBoardsMenuItem => 'كل الألواح';
+
+  @override
   String get yourCardsHeader => 'لوحاتك';
+
+  @override
+  String get noBoardsYet => 'لا توجد ألواح بعد';
+
+  @override
+  String get pageNotFoundTitle => 'الصفحة غير موجودة';
+
+  @override
+  String get homeButton => 'الرئيسية';
+
+  @override
+  String revenueCatUserIdLabel(String userId) {
+    return 'معرّف مستخدم RevenueCat: $userId';
+  }
+
+  @override
+  String get copyRevenueCatUserIdTooltip => 'نسخ معرّف مستخدم RevenueCat';
+
+  @override
+  String get revenueCatUserIdCopiedToast => 'تم نسخ معرّف مستخدم RevenueCat.';
 
   @override
   String get settingsHeader => 'الإعدادات';
 
   @override
-  String get appearanceMenuItem => 'Appearance';
+  String get clearSettingsMenuItem => 'مسح الإعدادات';
+
+  @override
+  String get appearanceMenuItem => 'المظهر';
 
   @override
   String get settingsAppearanceSection => 'المظهر';
@@ -189,177 +215,175 @@ class AppLocalizationsAr extends AppLocalizations {
       'اعرض احتفالًا عند إكمال بنغو.';
 
   @override
-  String get preMadeTilesTitle => 'Pre-made tiles';
+  String get preMadeTilesTitle => 'خانات جاهزة';
 
   @override
   String get preMadeTilesSettingsDescription =>
-      'Create reusable tile text for future boards.';
+      'أنشئ نصوص خانات قابلة لإعادة الاستخدام للألواح القادمة.';
 
   @override
   String get preMadeTilesDescription =>
-      'Create reusable bingo entries here. When you create a new board, you can add them without typing everything again.';
+      'أنشئ هنا إدخالات بينغو قابلة لإعادة الاستخدام. عند إنشاء لوح جديد، يمكنك إضافتها دون كتابة كل شيء مرة أخرى.';
 
   @override
-  String get preMadeTilesSelectMode => 'Select';
+  String get preMadeTilesSelectMode => 'تحديد';
 
   @override
-  String get preMadeTilesEditMode => 'Edit';
+  String get preMadeTilesEditMode => 'تحرير';
 
   @override
-  String get preMadeTileHint => 'Tile text';
+  String get preMadeTileHint => 'نص الخانة';
 
   @override
-  String get preMadeTilesAdd => 'Add tile';
+  String get preMadeTilesAdd => 'إضافة خانة';
 
   @override
-  String get preMadeTilesDelete => 'Delete tile';
+  String get preMadeTilesDelete => 'حذف خانة';
 
   @override
-  String get preMadeTilesSelectAll => 'Un/select all';
+  String get preMadeTilesSelectAll => 'تحديد/إلغاء تحديد الكل';
 
   @override
-  String get preMadeTilesSelectNone => 'Select none';
+  String get preMadeTilesSelectNone => 'إلغاء التحديد';
 
   @override
-  String get preMadeTilesApply => 'Apply';
+  String get preMadeTilesApply => 'تطبيق';
 
   @override
-  String get preMadeTilesReplaceItems => 'Replace items';
+  String get preMadeTilesReplaceItems => 'استبدال العناصر';
 
   @override
-  String get preMadeTilesFillItems => 'Fill items';
+  String get preMadeTilesFillItems => 'ملء العناصر';
 
   @override
   String get preMadeTilesBoardActionHelp =>
-      'Replace swaps the board entries with a random draw from your selection. Fill only adds items to empty tiles. On odd boards, the center tile stays in place.';
+      'الاستبدال يبدل إدخالات اللوح بسحب عشوائي من اختيارك. الملء يضيف العناصر إلى الخانات الفارغة فقط. في الألواح الفردية، تبقى الخانة الوسطى كما هي.';
 
   @override
   String preMadeTilesSelectedCount(int selected, int total) {
-    return '$selected / $total selected';
+    return '$selected / $total محددة';
   }
 
   @override
-  String get preMadeTilesEmptyTitle => 'No tiles yet';
+  String get preMadeTilesEmptyTitle => 'لا توجد خانات بعد';
 
   @override
   String get preMadeTilesEmptyBody =>
-      'Add a tile to start building a reusable list.';
+      'أضف خانة لبدء إنشاء قائمة قابلة لإعادة الاستخدام.';
 
   @override
-  String get proposeFeatures => 'Propose Features';
+  String get proposeFeatures => 'اقتراح ميزات';
 
   @override
   String get proposeFeaturesSettingsDescription =>
-      'Vote on ideas and suggest what to build next.';
+      'صوّت على الأفكار واقترح ما يجب بناؤه لاحقًا.';
 
   @override
-  String get supportMeDirectly => 'Support the developer';
+  String get supportMeDirectly => 'دعم المطور';
 
   @override
   String get supportMeDirectlySettingsDescription =>
-      'Help fund development and keep the app improving.';
+      'ساعد في تمويل التطوير والحفاظ على تحسين التطبيق.';
 
   @override
-  String get supportCarouselProTitle => 'Support Custom Bingo';
+  String get supportCarouselProTitle => 'ادعم Custom Bingo';
 
   @override
   String get supportCarouselProSubtitle =>
-      'Unlock bonus colors and help keep the app independent.';
+      'افتح ألوانًا إضافية وساعد في بقاء التطبيق مستقلًا.';
 
   @override
-  String get supportCarouselRateTitle => 'Enjoying the app?';
+  String get supportCarouselRateTitle => 'هل تستمتع بالتطبيق؟';
 
   @override
   String get supportCarouselRateSubtitle =>
-      'A quick review helps more people find Custom Bingo.';
+      'تقييم سريع يساعد المزيد من الناس على العثور على Custom Bingo.';
 
   @override
-  String get rateTheApp => 'Rate the app';
+  String get rateTheApp => 'تقييم التطبيق';
 
   @override
-  String get rateTheAppSettingsDescription => 'Open the store rating prompt.';
+  String get rateTheAppSettingsDescription => 'فتح طلب التقييم في المتجر.';
 
   @override
-  String get contactMe => 'Contact me';
+  String get contactMe => 'تواصل معي';
 
   @override
   String get contactMeSettingsDescription =>
-      'Send feedback, questions, or bug reports by email.';
+      'أرسل ملاحظات أو أسئلة أو تقارير أخطاء عبر البريد الإلكتروني.';
 
   @override
-  String get paywallTitle => 'Support Custom Bingo';
+  String get paywallTitle => 'ادعم Custom Bingo';
 
   @override
-  String get paywallThankYouTitle => 'Thank you';
+  String get paywallThankYouTitle => 'شكرًا لك';
 
   @override
-  String get paywallSupportTitle => 'Support Custom Bingo';
+  String get paywallSupportTitle => 'ادعم Custom Bingo';
 
   @override
   String get paywallSupportBody =>
-      'This purchase supports me, the developer, directly. You get my gratitude and a few small bonus things for your boards.';
+      'هذا الشراء يدعمني مباشرة بصفتي المطور. تحصل على امتناني وبعض الإضافات الصغيرة لألواحك.';
 
   @override
-  String get paywallBonusGratitude => 'My gratitude, sincerely.';
+  String get paywallBonusGratitude => 'امتناني الصادق.';
 
   @override
-  String get paywallBonusColors => 'A few extra board colors.';
+  String get paywallBonusColors => 'بعض ألوان الألواح الإضافية.';
 
   @override
-  String get paywallBonusExtras => 'Small supporter extras over time.';
+  String get paywallBonusExtras => 'إضافات صغيرة للداعمين مع الوقت.';
 
   @override
   String get paywallFreeForever =>
-      'No one ever needs to pay for this app. Custom Bingo stays usable for everyone.';
+      'لا يحتاج أحد أبدًا إلى الدفع لاستخدام هذا التطبيق. سيبقى Custom Bingo متاحًا للجميع.';
 
   @override
-  String get paywallLoadingPrice => 'Loading price';
+  String get paywallLoadingPrice => 'جارٍ تحميل السعر';
 
   @override
-  String get paywallUnavailable => 'Unavailable';
+  String get paywallUnavailable => 'غير متاح';
 
   @override
-  String get paywallSupportOnce => 'Support once';
+  String get paywallSupportOnce => 'ادعم مرة واحدة';
 
   @override
-  String get paywallRestorePurchase => 'Restore purchase';
+  String get paywallRestorePurchase => 'استعادة الشراء';
 
   @override
-  String get paywallProActiveToast => 'Custom Bingo Pro is active.';
+  String get paywallProActiveToast => 'Custom Bingo Pro نشط.';
 
   @override
-  String get paywallPurchaseInactiveToast =>
-      'Purchase finished, but Pro is not active.';
+  String get paywallPurchaseInactiveToast => 'اكتمل الشراء، لكن Pro غير نشط.';
 
   @override
-  String get paywallProRestoredToast => 'Custom Bingo Pro restored.';
+  String get paywallProRestoredToast => 'تمت استعادة Custom Bingo Pro.';
 
   @override
-  String get paywallNoPurchaseFoundToast => 'No Pro purchase found.';
+  String get paywallNoPurchaseFoundToast => 'لم يتم العثور على شراء Pro.';
 
   @override
-  String get paywallPurchasesUnavailable =>
-      'Purchases are unavailable right now.';
+  String get paywallPurchasesUnavailable => 'المشتريات غير متاحة الآن.';
 
   @override
   String get paywallPlatformUnavailable =>
-      'Purchases are unavailable on this platform.';
+      'المشتريات غير متاحة على هذا النظام.';
 
   @override
-  String get paywallCouldNotLoad => 'Could not load purchase information.';
+  String get paywallCouldNotLoad => 'تعذر تحميل معلومات الشراء.';
 
   @override
   String get shareTitle => 'مشاركة بطاقة البنغو';
 
   @override
-  String get shareDialogPrompt => 'How would you like to share?';
+  String get shareDialogPrompt => 'كيف تريد المشاركة؟';
 
   @override
   String get shareImageOptionTitle => 'مشاركة كصورة';
 
   @override
   String get shareImageOptionHelper =>
-      'Send a picture of your card. Anyone can see it — even without the app.';
+      'أرسل صورة لبطاقتك. يمكن لأي شخص رؤيتها حتى بدون التطبيق.';
 
   @override
   String get shareImageOptionButton => 'مشاركة الصورة';
@@ -369,14 +393,14 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get shareInviteOptionHelper =>
-      'Send this link to your friends who also have this app installed. They get the same card and you can play together.';
+      'أرسل هذا الرابط إلى أصدقائك الذين لديهم هذا التطبيق أيضًا. سيحصلون على نفس البطاقة ويمكنكم اللعب معًا.';
 
   @override
-  String get shareInviteIncludeMarks => 'Include my checkmarks';
+  String get shareInviteIncludeMarks => 'تضمين علاماتي';
 
   @override
   String get shareInviteIncludeMarksHelper =>
-      'When on, your friends will see what you\'ve already crossed off.';
+      'عند التفعيل، سيرى أصدقاؤك ما شطبته بالفعل.';
 
   @override
   String get shareInviteOptionButton => 'إرسال الدعوة';
@@ -390,13 +414,13 @@ class AppLocalizationsAr extends AppLocalizations {
   String get close => 'إغلاق';
 
   @override
-  String get shareSubject => 'Bingo Card';
+  String get shareSubject => 'بطاقة بينغو';
 
   @override
-  String get importTitle => 'A friend shared a bingo card with you';
+  String get importTitle => 'شارك صديق بطاقة بينغو معك';
 
   @override
-  String get importBody => 'Add it to your cards so you can play along?';
+  String get importBody => 'هل تريد إضافتها إلى بطاقاتك لتلعب معه؟';
 
   @override
   String get importConfirm => 'إضافة إلى بطاقاتي';
@@ -406,15 +430,15 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String importCollisionToast(String newName) {
-    return 'You already had a card with this name, so I added it as \"$newName\".';
+    return 'كانت لديك بطاقة بهذا الاسم، لذلك أضفتها باسم \"$newName\".';
   }
 
   @override
   String get importBadLinkToast =>
-      'Sorry, this invite couldn\'t be opened. Ask your friend to send it again.';
+      'عذرًا، تعذر فتح هذه الدعوة. اطلب من صديقك إرسالها مرة أخرى.';
 
   @override
-  String get importOutdatedAppToast => 'Update the app to open this invite.';
+  String get importOutdatedAppToast => 'حدّث التطبيق لفتح هذه الدعوة.';
 
   @override
   String get toastInfo => 'معلومة';
@@ -435,42 +459,41 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get screenshotCaptionPlaying =>
-      'Just a simple app to create bingo board.\n\nNo signup, no ads, fully free to use.';
+      'تطبيق بسيط لإنشاء لوح بينغو.\\n\\nبدون تسجيل، بدون إعلانات، ومجاني بالكامل.';
 
   @override
-  String get screenshotCaptionCreate =>
-      'Literally just 2 screens to create a bingo grid.';
+  String get screenshotCaptionCreate => 'شاشتان فقط لإنشاء شبكة بينغو.';
 
   @override
-  String get screenshotCaptionLocked => 'That\'s it.';
+  String get screenshotCaptionLocked => 'هذا كل شيء.';
 
   @override
-  String get screenshotBoardName => 'David\'s Wedding';
+  String get screenshotBoardName => 'زفاف ديفيد';
 
   @override
-  String get screenshotTilePhoneDuringVows => 'Phone during vows';
+  String get screenshotTilePhoneDuringVows => 'هاتف أثناء الوعود';
 
   @override
-  String get screenshotTileChampagneSpilled => 'Champagne spilled';
+  String get screenshotTileChampagneSpilled => 'انسكاب الشمبانيا';
 
   @override
-  String get screenshotTileSpeechTears => 'Speech tears';
+  String get screenshotTileSpeechTears => 'دموع أثناء الخطاب';
 
   @override
-  String get screenshotTileDramaticEntrance => 'Dramatic entrance';
+  String get screenshotTileDramaticEntrance => 'دخول درامي';
 
   @override
-  String get screenshotTileKidsDanceFloor => 'Kids take the dance floor';
+  String get screenshotTileKidsDanceFloor => 'الأطفال على ساحة الرقص';
 
   @override
-  String get screenshotTileGuestToast => 'Guest gives a toast';
+  String get screenshotTileGuestToast => 'ضيف يرفع نخبًا';
 
   @override
-  String get screenshotTileCrowdClapsEarly => 'Crowd claps early';
+  String get screenshotTileCrowdClapsEarly => 'تصفيق مبكر';
 
   @override
-  String get screenshotTileDjClassic => 'DJ plays a classic';
+  String get screenshotTileDjClassic => 'الدي جي يشغل أغنية كلاسيكية';
 
   @override
-  String get screenshotTileGroupPhotoChaos => 'Group photo chaos';
+  String get screenshotTileGroupPhotoChaos => 'فوضى صورة جماعية';
 }

--- a/lib/l10n/arb/app_localizations_ar.dart
+++ b/lib/l10n/arb/app_localizations_ar.dart
@@ -4,27 +4,27 @@ import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
 
-/// The translations for English (`en`).
-class AppLocalizationsEn extends AppLocalizations {
-  AppLocalizationsEn([String locale = 'en']) : super(locale);
+/// The translations for Arabic (`ar`).
+class AppLocalizationsAr extends AppLocalizations {
+  AppLocalizationsAr([String locale = 'ar']) : super(locale);
 
   @override
-  String get newCardTitle => 'Create New Bingo Grid';
+  String get newCardTitle => 'إنشاء شبكة بنغو جديدة';
 
   @override
-  String get editCardTitle => 'Edit Bingo Grid';
+  String get editCardTitle => 'تعديل شبكة البنغو';
 
   @override
-  String get cardNameLabel => 'Bingo Grid Name *';
+  String get cardNameLabel => 'اسم شبكة البنغو *';
 
   @override
-  String get cardNameHint => 'Enter a name for your bingo grid';
+  String get cardNameHint => 'أدخل اسمًا لشبكة البنغو';
 
   @override
-  String get createCardButton => 'Create Bingo Grid';
+  String get createCardButton => 'إنشاء شبكة البنغو';
 
   @override
-  String get updateCardButton => 'Update Bingo Grid';
+  String get updateCardButton => 'تحديث شبكة البنغو';
 
   @override
   String get newBoardPreMadeSectionTitle => 'Your pre-made items';
@@ -54,10 +54,10 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get defaultCardName => 'Bingo Card';
+  String get defaultCardName => 'بطاقة بنغو';
 
   @override
-  String get toggleHint => 'Press long to mark a field as checked';
+  String get toggleHint => 'اضغط مطولًا لوضع علامة على خانة';
 
   @override
   String get editingHintBefore => 'Press the lock icon';
@@ -72,10 +72,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get deleteCardConfirm => 'Are you sure you want to delete this card?';
 
   @override
-  String get cancel => 'Cancel';
+  String get cancel => 'إلغاء';
 
   @override
-  String get delete => 'Delete';
+  String get delete => 'حذف';
 
   @override
   String get shuffleCardTitle => 'Shuffle Card';
@@ -85,7 +85,7 @@ class AppLocalizationsEn extends AppLocalizations {
       'Are you sure you want to shuffle this card? All fields will be unchecked, after shuffling.';
 
   @override
-  String get shuffle => 'Shuffle';
+  String get shuffle => 'خلط';
 
   @override
   String get ratingPromptTitle => 'Do you like Custom Bingo?';
@@ -101,19 +101,19 @@ class AppLocalizationsEn extends AppLocalizations {
   String get ratingPromptYes => 'Yes, I like it';
 
   @override
-  String get boardActionShare => 'Share';
+  String get boardActionShare => 'مشاركة';
 
   @override
-  String get boardActionEditBoard => 'Edit board';
+  String get boardActionEditBoard => 'تعديل اللوحة';
 
   @override
   String get boardActionAddPreMadeItems => 'Add pre-made items';
 
   @override
-  String get cellHint => 'Enter text…';
+  String get cellHint => 'أدخل نصًا…';
 
   @override
-  String get edit => 'Edit';
+  String get edit => 'تعديل';
 
   @override
   String get markDone => 'Mark Done';
@@ -122,71 +122,71 @@ class AppLocalizationsEn extends AppLocalizations {
   String get markNotDone => 'Mark Not Done';
 
   @override
-  String get newCardMenuItem => 'New bingo board';
+  String get newCardMenuItem => 'لوحة بنغو جديدة';
 
   @override
-  String get yourCardsHeader => 'Your Boards';
+  String get yourCardsHeader => 'لوحاتك';
 
   @override
-  String get settingsHeader => 'Settings';
+  String get settingsHeader => 'الإعدادات';
 
   @override
   String get appearanceMenuItem => 'Appearance';
 
   @override
-  String get settingsAppearanceSection => 'Appearance';
+  String get settingsAppearanceSection => 'المظهر';
 
   @override
-  String get settingsPreferencesSection => 'Preferences';
+  String get settingsPreferencesSection => 'التفضيلات';
 
   @override
-  String get settingsBoardsSection => 'Boards';
+  String get settingsBoardsSection => 'اللوحات';
 
   @override
-  String get settingsHelpSection => 'More';
+  String get settingsHelpSection => 'المزيد';
 
   @override
-  String get settingsSupportSection => 'Support';
+  String get settingsSupportSection => 'الدعم';
 
   @override
-  String get themeColorLabel => 'Theme color';
+  String get themeColorLabel => 'لون السمة';
 
   @override
   String get themeColorSettingsDescription =>
-      'Choose the palette used across the app.';
+      'اختر لوحة الألوان المستخدمة في التطبيق.';
 
   @override
-  String get languageSettingsTitle => 'Language';
+  String get languageSettingsTitle => 'اللغة';
 
   @override
-  String get languageSettingsSelectorLabel => 'App language';
+  String get languageSettingsSelectorLabel => 'لغة التطبيق';
 
   @override
   String languageSettingsSystemOption(String language) {
-    return 'System default ($language)';
+    return 'إعداد النظام الافتراضي ($language)';
   }
 
   @override
   String languageSettingsSystemDescription(String language) {
-    return 'Following your phone language: $language.';
+    return 'يتبع لغة الهاتف: $language.';
   }
 
   @override
   String get languageSettingsOverrideDescription =>
-      'Use this language instead of the phone language.';
+      'استخدم هذه اللغة بدلًا من لغة الهاتف.';
 
   @override
-  String get darkModeLabel => 'Dark mode';
+  String get darkModeLabel => 'الوضع الداكن';
 
   @override
-  String get darkModeSettingsDescription => 'Use a darker interface.';
+  String get darkModeSettingsDescription => 'استخدم واجهة أغمق.';
 
   @override
-  String get enableConfettiLabel => 'Confetti';
+  String get enableConfettiLabel => 'قصاصات الاحتفال';
 
   @override
   String get enableConfettiSettingsDescription =>
-      'Show a celebration when you complete a bingo.';
+      'اعرض احتفالًا عند إكمال بنغو.';
 
   @override
   String get preMadeTilesTitle => 'Pre-made tiles';
@@ -349,23 +349,23 @@ class AppLocalizationsEn extends AppLocalizations {
   String get paywallCouldNotLoad => 'Could not load purchase information.';
 
   @override
-  String get shareTitle => 'Share the bingo card';
+  String get shareTitle => 'مشاركة بطاقة البنغو';
 
   @override
   String get shareDialogPrompt => 'How would you like to share?';
 
   @override
-  String get shareImageOptionTitle => 'Share as image';
+  String get shareImageOptionTitle => 'مشاركة كصورة';
 
   @override
   String get shareImageOptionHelper =>
       'Send a picture of your card. Anyone can see it — even without the app.';
 
   @override
-  String get shareImageOptionButton => 'Share image';
+  String get shareImageOptionButton => 'مشاركة الصورة';
 
   @override
-  String get shareInviteOptionTitle => 'Invite friends to play';
+  String get shareInviteOptionTitle => 'دعوة الأصدقاء للعب';
 
   @override
   String get shareInviteOptionHelper =>
@@ -379,15 +379,15 @@ class AppLocalizationsEn extends AppLocalizations {
       'When on, your friends will see what you\'ve already crossed off.';
 
   @override
-  String get shareInviteOptionButton => 'Send invite';
+  String get shareInviteOptionButton => 'إرسال الدعوة';
 
   @override
   String shareInviteText(String name, String link) {
-    return 'Play \"$name\" with me! Open it in the app:\n$link';
+    return 'العب \"$name\" معي! افتحه في التطبيق:\n$link';
   }
 
   @override
-  String get close => 'Close';
+  String get close => 'إغلاق';
 
   @override
   String get shareSubject => 'Bingo Card';
@@ -399,10 +399,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get importBody => 'Add it to your cards so you can play along?';
 
   @override
-  String get importConfirm => 'Add to my cards';
+  String get importConfirm => 'إضافة إلى بطاقاتي';
 
   @override
-  String get importCancel => 'Not now';
+  String get importCancel => 'ليس الآن';
 
   @override
   String importCollisionToast(String newName) {
@@ -417,20 +417,20 @@ class AppLocalizationsEn extends AppLocalizations {
   String get importOutdatedAppToast => 'Update the app to open this invite.';
 
   @override
-  String get toastInfo => 'Info';
+  String get toastInfo => 'معلومة';
 
   @override
-  String get toastSuccess => 'Success';
+  String get toastSuccess => 'نجاح';
 
   @override
-  String get toastError => 'Error';
+  String get toastError => 'خطأ';
 
   @override
-  String get lastChangeNever => 'Last change: Never';
+  String get lastChangeNever => 'آخر تغيير: أبدًا';
 
   @override
   String lastChange(String date, String time) {
-    return 'Last change: $date $time';
+    return 'آخر تغيير: $date $time';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -157,6 +157,26 @@ class AppLocalizationsDe extends AppLocalizations {
       'Wähle die Farbpalette für die App.';
 
   @override
+  String get languageSettingsTitle => 'Sprache';
+
+  @override
+  String get languageSettingsSelectorLabel => 'App-Sprache';
+
+  @override
+  String languageSettingsSystemOption(String language) {
+    return 'Systemstandard ($language)';
+  }
+
+  @override
+  String languageSettingsSystemDescription(String language) {
+    return 'Folgt deiner Telefonsprache: $language.';
+  }
+
+  @override
+  String get languageSettingsOverrideDescription =>
+      'Diese Sprache statt der Telefonsprache verwenden.';
+
+  @override
   String get darkModeLabel => 'Dunkler Modus';
 
   @override

--- a/lib/l10n/arb/app_localizations_de.dart
+++ b/lib/l10n/arb/app_localizations_de.dart
@@ -126,10 +126,36 @@ class AppLocalizationsDe extends AppLocalizations {
   String get newCardMenuItem => 'Neues Bingo';
 
   @override
+  String get allBoardsMenuItem => 'Alle Boards';
+
+  @override
   String get yourCardsHeader => 'Deine Bingos';
 
   @override
+  String get noBoardsYet => 'Noch keine Boards';
+
+  @override
+  String get pageNotFoundTitle => 'Seite nicht gefunden';
+
+  @override
+  String get homeButton => 'Startseite';
+
+  @override
+  String revenueCatUserIdLabel(String userId) {
+    return 'RevenueCat-Benutzer-ID: $userId';
+  }
+
+  @override
+  String get copyRevenueCatUserIdTooltip => 'RevenueCat-Benutzer-ID kopieren';
+
+  @override
+  String get revenueCatUserIdCopiedToast => 'RevenueCat-Benutzer-ID kopiert.';
+
+  @override
   String get settingsHeader => 'Einstellungen';
+
+  @override
+  String get clearSettingsMenuItem => 'Einstellungen löschen';
 
   @override
   String get appearanceMenuItem => 'Design';
@@ -141,7 +167,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settingsPreferencesSection => 'Einstellungen';
 
   @override
-  String get settingsBoardsSection => 'Boards';
+  String get settingsBoardsSection => 'Bingo-Boards';
 
   @override
   String get settingsHelpSection => 'Mehr';
@@ -423,7 +449,7 @@ class AppLocalizationsDe extends AppLocalizations {
       'Aktualisiere die App, um diese Einladung zu öffnen.';
 
   @override
-  String get toastInfo => 'Info';
+  String get toastInfo => 'Hinweis';
 
   @override
   String get toastSuccess => 'Erfolg';

--- a/lib/l10n/arb/app_localizations_en.dart
+++ b/lib/l10n/arb/app_localizations_en.dart
@@ -125,10 +125,36 @@ class AppLocalizationsEn extends AppLocalizations {
   String get newCardMenuItem => 'New bingo board';
 
   @override
+  String get allBoardsMenuItem => 'All boards';
+
+  @override
   String get yourCardsHeader => 'Your Boards';
 
   @override
+  String get noBoardsYet => 'No boards yet';
+
+  @override
+  String get pageNotFoundTitle => 'Page Not Found';
+
+  @override
+  String get homeButton => 'Home';
+
+  @override
+  String revenueCatUserIdLabel(String userId) {
+    return 'RevenueCat user id: $userId';
+  }
+
+  @override
+  String get copyRevenueCatUserIdTooltip => 'Copy RevenueCat user id';
+
+  @override
+  String get revenueCatUserIdCopiedToast => 'RevenueCat user id copied.';
+
+  @override
   String get settingsHeader => 'Settings';
+
+  @override
+  String get clearSettingsMenuItem => 'Clear Settings';
 
   @override
   String get appearanceMenuItem => 'Appearance';

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -27,30 +27,30 @@ class AppLocalizationsEs extends AppLocalizations {
   String get updateCardButton => 'Actualizar cuadrícula';
 
   @override
-  String get newBoardPreMadeSectionTitle => 'Your pre-made items';
+  String get newBoardPreMadeSectionTitle => 'Tus elementos preparados';
 
   @override
-  String get newBoardPreMadeButton => 'Start with pre-made items';
+  String get newBoardPreMadeButton => 'Empezar con elementos preparados';
 
   @override
-  String get newBoardPreMadeChangeButton => 'Change pre-made items';
+  String get newBoardPreMadeChangeButton => 'Cambiar elementos preparados';
 
   @override
-  String get newBoardPreMadeClearButton => 'Clear pre-made items';
+  String get newBoardPreMadeClearButton => 'Borrar elementos preparados';
 
   @override
   String newBoardPreMadeAppliedCount(int count) {
-    return '$count pre-made entries applied';
+    return '$count entradas preparadas aplicadas';
   }
 
   @override
   String newBoardPreMadeFullSummary(int used) {
-    return '$used will be drawn at random for this board.';
+    return 'Se elegirán $used al azar para este tablero.';
   }
 
   @override
   String newBoardPreMadePartialSummary(int used, int blank) {
-    return '$used cells will be filled. $blank will stay blank.';
+    return 'Se rellenarán $used casillas. $blank quedarán vacías.';
   }
 
   @override
@@ -60,16 +60,17 @@ class AppLocalizationsEs extends AppLocalizations {
   String get toggleHint => 'Mantén pulsado para marcar una casilla';
 
   @override
-  String get editingHintBefore => 'Press the lock icon';
+  String get editingHintBefore => 'Pulsa el icono de candado';
 
   @override
-  String get editingHintAfter => ' to make the fields not editable anymore.';
+  String get editingHintAfter =>
+      ' para que las casillas dejen de ser editables.';
 
   @override
-  String get deleteCardTitle => 'Delete Card';
+  String get deleteCardTitle => 'Eliminar tarjeta';
 
   @override
-  String get deleteCardConfirm => 'Are you sure you want to delete this card?';
+  String get deleteCardConfirm => '¿Seguro que quieres eliminar esta tarjeta?';
 
   @override
   String get cancel => 'Cancelar';
@@ -78,27 +79,27 @@ class AppLocalizationsEs extends AppLocalizations {
   String get delete => 'Eliminar';
 
   @override
-  String get shuffleCardTitle => 'Shuffle Card';
+  String get shuffleCardTitle => 'Mezclar tarjeta';
 
   @override
   String get shuffleCardConfirm =>
-      'Are you sure you want to shuffle this card? All fields will be unchecked, after shuffling.';
+      '¿Seguro que quieres mezclar esta tarjeta? Todas las casillas quedarán desmarcadas después.';
 
   @override
   String get shuffle => 'Mezclar';
 
   @override
-  String get ratingPromptTitle => 'Do you like Custom Bingo?';
+  String get ratingPromptTitle => '¿Te gusta Custom Bingo?';
 
   @override
   String get ratingPromptBody =>
-      'If so, a quick store review helps others find it.';
+      'Si es así, una reseña rápida en la tienda ayuda a que más personas la encuentren.';
 
   @override
-  String get ratingPromptNo => 'Not really';
+  String get ratingPromptNo => 'No mucho';
 
   @override
-  String get ratingPromptYes => 'Yes, I like it';
+  String get ratingPromptYes => 'Sí, me gusta';
 
   @override
   String get boardActionShare => 'Compartir';
@@ -107,7 +108,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get boardActionEditBoard => 'Editar tablero';
 
   @override
-  String get boardActionAddPreMadeItems => 'Add pre-made items';
+  String get boardActionAddPreMadeItems => 'Añadir elementos preparados';
 
   @override
   String get cellHint => 'Escribe texto…';
@@ -116,22 +117,50 @@ class AppLocalizationsEs extends AppLocalizations {
   String get edit => 'Editar';
 
   @override
-  String get markDone => 'Mark Done';
+  String get markDone => 'Marcar como hecho';
 
   @override
-  String get markNotDone => 'Mark Not Done';
+  String get markNotDone => 'Marcar como no hecho';
 
   @override
   String get newCardMenuItem => 'Nuevo tablero de bingo';
 
   @override
+  String get allBoardsMenuItem => 'Todos los tableros';
+
+  @override
   String get yourCardsHeader => 'Tus tableros';
+
+  @override
+  String get noBoardsYet => 'Aún no hay tableros';
+
+  @override
+  String get pageNotFoundTitle => 'Página no encontrada';
+
+  @override
+  String get homeButton => 'Inicio';
+
+  @override
+  String revenueCatUserIdLabel(String userId) {
+    return 'ID de usuario de RevenueCat: $userId';
+  }
+
+  @override
+  String get copyRevenueCatUserIdTooltip =>
+      'Copiar ID de usuario de RevenueCat';
+
+  @override
+  String get revenueCatUserIdCopiedToast =>
+      'ID de usuario de RevenueCat copiado.';
 
   @override
   String get settingsHeader => 'Ajustes';
 
   @override
-  String get appearanceMenuItem => 'Appearance';
+  String get clearSettingsMenuItem => 'Borrar ajustes';
+
+  @override
+  String get appearanceMenuItem => 'Apariencia';
 
   @override
   String get settingsAppearanceSection => 'Apariencia';
@@ -189,177 +218,181 @@ class AppLocalizationsEs extends AppLocalizations {
       'Mostrar una celebración al completar un bingo.';
 
   @override
-  String get preMadeTilesTitle => 'Pre-made tiles';
+  String get preMadeTilesTitle => 'Casillas preparadas';
 
   @override
   String get preMadeTilesSettingsDescription =>
-      'Create reusable tile text for future boards.';
+      'Crea textos de casilla reutilizables para futuros tableros.';
 
   @override
   String get preMadeTilesDescription =>
-      'Create reusable bingo entries here. When you create a new board, you can add them without typing everything again.';
+      'Crea aquí entradas de bingo reutilizables. Cuando crees un tablero nuevo, podrás añadirlas sin volver a escribirlo todo.';
 
   @override
-  String get preMadeTilesSelectMode => 'Select';
+  String get preMadeTilesSelectMode => 'Seleccionar';
 
   @override
-  String get preMadeTilesEditMode => 'Edit';
+  String get preMadeTilesEditMode => 'Editar';
 
   @override
-  String get preMadeTileHint => 'Tile text';
+  String get preMadeTileHint => 'Texto de la casilla';
 
   @override
-  String get preMadeTilesAdd => 'Add tile';
+  String get preMadeTilesAdd => 'Añadir casilla';
 
   @override
-  String get preMadeTilesDelete => 'Delete tile';
+  String get preMadeTilesDelete => 'Eliminar casilla';
 
   @override
-  String get preMadeTilesSelectAll => 'Un/select all';
+  String get preMadeTilesSelectAll => 'Seleccionar/deseleccionar todo';
 
   @override
-  String get preMadeTilesSelectNone => 'Select none';
+  String get preMadeTilesSelectNone => 'No seleccionar nada';
 
   @override
-  String get preMadeTilesApply => 'Apply';
+  String get preMadeTilesApply => 'Aplicar';
 
   @override
-  String get preMadeTilesReplaceItems => 'Replace items';
+  String get preMadeTilesReplaceItems => 'Reemplazar elementos';
 
   @override
-  String get preMadeTilesFillItems => 'Fill items';
+  String get preMadeTilesFillItems => 'Rellenar elementos';
 
   @override
   String get preMadeTilesBoardActionHelp =>
-      'Replace swaps the board entries with a random draw from your selection. Fill only adds items to empty tiles. On odd boards, the center tile stays in place.';
+      'Reemplazar cambia las entradas del tablero por una selección aleatoria. Rellenar solo añade elementos a casillas vacías. En tableros impares, la casilla central se mantiene.';
 
   @override
   String preMadeTilesSelectedCount(int selected, int total) {
-    return '$selected / $total selected';
+    return '$selected / $total seleccionadas';
   }
 
   @override
-  String get preMadeTilesEmptyTitle => 'No tiles yet';
+  String get preMadeTilesEmptyTitle => 'Aún no hay casillas';
 
   @override
   String get preMadeTilesEmptyBody =>
-      'Add a tile to start building a reusable list.';
+      'Añade una casilla para empezar una lista reutilizable.';
 
   @override
-  String get proposeFeatures => 'Propose Features';
+  String get proposeFeatures => 'Proponer funciones';
 
   @override
   String get proposeFeaturesSettingsDescription =>
-      'Vote on ideas and suggest what to build next.';
+      'Vota ideas y sugiere qué crear después.';
 
   @override
-  String get supportMeDirectly => 'Support the developer';
+  String get supportMeDirectly => 'Apoyar al desarrollador';
 
   @override
   String get supportMeDirectlySettingsDescription =>
-      'Help fund development and keep the app improving.';
+      'Ayuda a financiar el desarrollo y a seguir mejorando la app.';
 
   @override
-  String get supportCarouselProTitle => 'Support Custom Bingo';
+  String get supportCarouselProTitle => 'Apoya Custom Bingo';
 
   @override
   String get supportCarouselProSubtitle =>
-      'Unlock bonus colors and help keep the app independent.';
+      'Desbloquea colores extra y ayuda a mantener la app independiente.';
 
   @override
-  String get supportCarouselRateTitle => 'Enjoying the app?';
+  String get supportCarouselRateTitle => '¿Disfrutas la app?';
 
   @override
   String get supportCarouselRateSubtitle =>
-      'A quick review helps more people find Custom Bingo.';
+      'Una reseña rápida ayuda a que más personas encuentren Custom Bingo.';
 
   @override
-  String get rateTheApp => 'Rate the app';
+  String get rateTheApp => 'Valorar la app';
 
   @override
-  String get rateTheAppSettingsDescription => 'Open the store rating prompt.';
+  String get rateTheAppSettingsDescription =>
+      'Abrir la solicitud de valoración de la tienda.';
 
   @override
-  String get contactMe => 'Contact me';
+  String get contactMe => 'Contactarme';
 
   @override
   String get contactMeSettingsDescription =>
-      'Send feedback, questions, or bug reports by email.';
+      'Envía comentarios, preguntas o informes de errores por email.';
 
   @override
-  String get paywallTitle => 'Support Custom Bingo';
+  String get paywallTitle => 'Apoya Custom Bingo';
 
   @override
-  String get paywallThankYouTitle => 'Thank you';
+  String get paywallThankYouTitle => 'Gracias';
 
   @override
-  String get paywallSupportTitle => 'Support Custom Bingo';
+  String get paywallSupportTitle => 'Apoya Custom Bingo';
 
   @override
   String get paywallSupportBody =>
-      'This purchase supports me, the developer, directly. You get my gratitude and a few small bonus things for your boards.';
+      'Esta compra me apoya directamente a mí, el desarrollador. Recibes mi agradecimiento y algunos pequeños extras para tus tableros.';
 
   @override
-  String get paywallBonusGratitude => 'My gratitude, sincerely.';
+  String get paywallBonusGratitude => 'Mi agradecimiento, de verdad.';
 
   @override
-  String get paywallBonusColors => 'A few extra board colors.';
+  String get paywallBonusColors => 'Algunos colores extra para tableros.';
 
   @override
-  String get paywallBonusExtras => 'Small supporter extras over time.';
+  String get paywallBonusExtras =>
+      'Pequeños extras para seguidores con el tiempo.';
 
   @override
   String get paywallFreeForever =>
-      'No one ever needs to pay for this app. Custom Bingo stays usable for everyone.';
+      'Nadie necesita pagar nunca por esta app. Custom Bingo seguirá siendo usable para todos.';
 
   @override
-  String get paywallLoadingPrice => 'Loading price';
+  String get paywallLoadingPrice => 'Cargando precio';
 
   @override
-  String get paywallUnavailable => 'Unavailable';
+  String get paywallUnavailable => 'No disponible';
 
   @override
-  String get paywallSupportOnce => 'Support once';
+  String get paywallSupportOnce => 'Apoyar una vez';
 
   @override
-  String get paywallRestorePurchase => 'Restore purchase';
+  String get paywallRestorePurchase => 'Restaurar compra';
 
   @override
-  String get paywallProActiveToast => 'Custom Bingo Pro is active.';
+  String get paywallProActiveToast => 'Custom Bingo Pro está activo.';
 
   @override
   String get paywallPurchaseInactiveToast =>
-      'Purchase finished, but Pro is not active.';
+      'La compra terminó, pero Pro no está activo.';
 
   @override
-  String get paywallProRestoredToast => 'Custom Bingo Pro restored.';
+  String get paywallProRestoredToast => 'Custom Bingo Pro restaurado.';
 
   @override
-  String get paywallNoPurchaseFoundToast => 'No Pro purchase found.';
+  String get paywallNoPurchaseFoundToast =>
+      'No se encontró ninguna compra Pro.';
 
   @override
   String get paywallPurchasesUnavailable =>
-      'Purchases are unavailable right now.';
+      'Las compras no están disponibles ahora mismo.';
 
   @override
   String get paywallPlatformUnavailable =>
-      'Purchases are unavailable on this platform.';
+      'Las compras no están disponibles en esta plataforma.';
 
   @override
-  String get paywallCouldNotLoad => 'Could not load purchase information.';
+  String get paywallCouldNotLoad =>
+      'No se pudo cargar la información de compra.';
 
   @override
   String get shareTitle => 'Compartir la tarjeta de bingo';
 
   @override
-  String get shareDialogPrompt => 'How would you like to share?';
+  String get shareDialogPrompt => '¿Cómo quieres compartir?';
 
   @override
   String get shareImageOptionTitle => 'Compartir como imagen';
 
   @override
   String get shareImageOptionHelper =>
-      'Send a picture of your card. Anyone can see it — even without the app.';
+      'Envía una imagen de tu tarjeta. Cualquiera puede verla, incluso sin la app.';
 
   @override
   String get shareImageOptionButton => 'Compartir imagen';
@@ -369,14 +402,14 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get shareInviteOptionHelper =>
-      'Send this link to your friends who also have this app installed. They get the same card and you can play together.';
+      'Envía este enlace a tus amigos que también tengan esta app instalada. Recibirán la misma tarjeta y podréis jugar juntos.';
 
   @override
-  String get shareInviteIncludeMarks => 'Include my checkmarks';
+  String get shareInviteIncludeMarks => 'Incluir mis marcas';
 
   @override
   String get shareInviteIncludeMarksHelper =>
-      'When on, your friends will see what you\'ve already crossed off.';
+      'Cuando esté activado, tus amigos verán lo que ya has tachado.';
 
   @override
   String get shareInviteOptionButton => 'Enviar invitación';
@@ -390,13 +423,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get close => 'Cerrar';
 
   @override
-  String get shareSubject => 'Bingo Card';
+  String get shareSubject => 'Tarjeta de bingo';
 
   @override
-  String get importTitle => 'A friend shared a bingo card with you';
+  String get importTitle => 'Un amigo compartió una tarjeta de bingo contigo';
 
   @override
-  String get importBody => 'Add it to your cards so you can play along?';
+  String get importBody => '¿Añadirla a tus tarjetas para jugar?';
 
   @override
   String get importConfirm => 'Añadir a mis tarjetas';
@@ -406,15 +439,16 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String importCollisionToast(String newName) {
-    return 'You already had a card with this name, so I added it as \"$newName\".';
+    return 'Ya tenías una tarjeta con este nombre, así que la añadí como \"$newName\".';
   }
 
   @override
   String get importBadLinkToast =>
-      'Sorry, this invite couldn\'t be opened. Ask your friend to send it again.';
+      'Lo siento, no se pudo abrir esta invitación. Pide a tu amigo que la envíe otra vez.';
 
   @override
-  String get importOutdatedAppToast => 'Update the app to open this invite.';
+  String get importOutdatedAppToast =>
+      'Actualiza la app para abrir esta invitación.';
 
   @override
   String get toastInfo => 'Información';
@@ -423,7 +457,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get toastSuccess => 'Éxito';
 
   @override
-  String get toastError => 'Error';
+  String get toastError => 'Fallo';
 
   @override
   String get lastChangeNever => 'Último cambio: nunca';
@@ -435,42 +469,42 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get screenshotCaptionPlaying =>
-      'Just a simple app to create bingo board.\n\nNo signup, no ads, fully free to use.';
+      'Una app sencilla para crear tableros de bingo.\\n\\nSin registro, sin anuncios y totalmente gratis.';
 
   @override
   String get screenshotCaptionCreate =>
-      'Literally just 2 screens to create a bingo grid.';
+      'Literalmente solo dos pantallas para crear una cuadrícula de bingo.';
 
   @override
-  String get screenshotCaptionLocked => 'That\'s it.';
+  String get screenshotCaptionLocked => 'Eso es todo.';
 
   @override
-  String get screenshotBoardName => 'David\'s Wedding';
+  String get screenshotBoardName => 'La boda de David';
 
   @override
-  String get screenshotTilePhoneDuringVows => 'Phone during vows';
+  String get screenshotTilePhoneDuringVows => 'Teléfono durante los votos';
 
   @override
-  String get screenshotTileChampagneSpilled => 'Champagne spilled';
+  String get screenshotTileChampagneSpilled => 'Champán derramado';
 
   @override
-  String get screenshotTileSpeechTears => 'Speech tears';
+  String get screenshotTileSpeechTears => 'Lágrimas en el discurso';
 
   @override
-  String get screenshotTileDramaticEntrance => 'Dramatic entrance';
+  String get screenshotTileDramaticEntrance => 'Entrada dramática';
 
   @override
-  String get screenshotTileKidsDanceFloor => 'Kids take the dance floor';
+  String get screenshotTileKidsDanceFloor => 'Niños en la pista';
 
   @override
-  String get screenshotTileGuestToast => 'Guest gives a toast';
+  String get screenshotTileGuestToast => 'Un invitado brinda';
 
   @override
-  String get screenshotTileCrowdClapsEarly => 'Crowd claps early';
+  String get screenshotTileCrowdClapsEarly => 'Aplausos antes de tiempo';
 
   @override
-  String get screenshotTileDjClassic => 'DJ plays a classic';
+  String get screenshotTileDjClassic => 'El DJ pone un clásico';
 
   @override
-  String get screenshotTileGroupPhotoChaos => 'Group photo chaos';
+  String get screenshotTileGroupPhotoChaos => 'Caos en la foto de grupo';
 }

--- a/lib/l10n/arb/app_localizations_es.dart
+++ b/lib/l10n/arb/app_localizations_es.dart
@@ -4,27 +4,27 @@ import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
 
-/// The translations for English (`en`).
-class AppLocalizationsEn extends AppLocalizations {
-  AppLocalizationsEn([String locale = 'en']) : super(locale);
+/// The translations for Spanish Castilian (`es`).
+class AppLocalizationsEs extends AppLocalizations {
+  AppLocalizationsEs([String locale = 'es']) : super(locale);
 
   @override
-  String get newCardTitle => 'Create New Bingo Grid';
+  String get newCardTitle => 'Crear nueva cuadrícula de bingo';
 
   @override
-  String get editCardTitle => 'Edit Bingo Grid';
+  String get editCardTitle => 'Editar cuadrícula de bingo';
 
   @override
-  String get cardNameLabel => 'Bingo Grid Name *';
+  String get cardNameLabel => 'Nombre de la cuadrícula *';
 
   @override
-  String get cardNameHint => 'Enter a name for your bingo grid';
+  String get cardNameHint => 'Ponle nombre a tu cuadrícula de bingo';
 
   @override
-  String get createCardButton => 'Create Bingo Grid';
+  String get createCardButton => 'Crear cuadrícula';
 
   @override
-  String get updateCardButton => 'Update Bingo Grid';
+  String get updateCardButton => 'Actualizar cuadrícula';
 
   @override
   String get newBoardPreMadeSectionTitle => 'Your pre-made items';
@@ -54,10 +54,10 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get defaultCardName => 'Bingo Card';
+  String get defaultCardName => 'Tarjeta de bingo';
 
   @override
-  String get toggleHint => 'Press long to mark a field as checked';
+  String get toggleHint => 'Mantén pulsado para marcar una casilla';
 
   @override
   String get editingHintBefore => 'Press the lock icon';
@@ -72,10 +72,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get deleteCardConfirm => 'Are you sure you want to delete this card?';
 
   @override
-  String get cancel => 'Cancel';
+  String get cancel => 'Cancelar';
 
   @override
-  String get delete => 'Delete';
+  String get delete => 'Eliminar';
 
   @override
   String get shuffleCardTitle => 'Shuffle Card';
@@ -85,7 +85,7 @@ class AppLocalizationsEn extends AppLocalizations {
       'Are you sure you want to shuffle this card? All fields will be unchecked, after shuffling.';
 
   @override
-  String get shuffle => 'Shuffle';
+  String get shuffle => 'Mezclar';
 
   @override
   String get ratingPromptTitle => 'Do you like Custom Bingo?';
@@ -101,19 +101,19 @@ class AppLocalizationsEn extends AppLocalizations {
   String get ratingPromptYes => 'Yes, I like it';
 
   @override
-  String get boardActionShare => 'Share';
+  String get boardActionShare => 'Compartir';
 
   @override
-  String get boardActionEditBoard => 'Edit board';
+  String get boardActionEditBoard => 'Editar tablero';
 
   @override
   String get boardActionAddPreMadeItems => 'Add pre-made items';
 
   @override
-  String get cellHint => 'Enter text…';
+  String get cellHint => 'Escribe texto…';
 
   @override
-  String get edit => 'Edit';
+  String get edit => 'Editar';
 
   @override
   String get markDone => 'Mark Done';
@@ -122,71 +122,71 @@ class AppLocalizationsEn extends AppLocalizations {
   String get markNotDone => 'Mark Not Done';
 
   @override
-  String get newCardMenuItem => 'New bingo board';
+  String get newCardMenuItem => 'Nuevo tablero de bingo';
 
   @override
-  String get yourCardsHeader => 'Your Boards';
+  String get yourCardsHeader => 'Tus tableros';
 
   @override
-  String get settingsHeader => 'Settings';
+  String get settingsHeader => 'Ajustes';
 
   @override
   String get appearanceMenuItem => 'Appearance';
 
   @override
-  String get settingsAppearanceSection => 'Appearance';
+  String get settingsAppearanceSection => 'Apariencia';
 
   @override
-  String get settingsPreferencesSection => 'Preferences';
+  String get settingsPreferencesSection => 'Preferencias';
 
   @override
-  String get settingsBoardsSection => 'Boards';
+  String get settingsBoardsSection => 'Tableros';
 
   @override
-  String get settingsHelpSection => 'More';
+  String get settingsHelpSection => 'Más';
 
   @override
-  String get settingsSupportSection => 'Support';
+  String get settingsSupportSection => 'Apoyo';
 
   @override
-  String get themeColorLabel => 'Theme color';
+  String get themeColorLabel => 'Color del tema';
 
   @override
   String get themeColorSettingsDescription =>
-      'Choose the palette used across the app.';
+      'Elige la paleta usada en toda la app.';
 
   @override
-  String get languageSettingsTitle => 'Language';
+  String get languageSettingsTitle => 'Idioma';
 
   @override
-  String get languageSettingsSelectorLabel => 'App language';
+  String get languageSettingsSelectorLabel => 'Idioma de la app';
 
   @override
   String languageSettingsSystemOption(String language) {
-    return 'System default ($language)';
+    return 'Predeterminado del sistema ($language)';
   }
 
   @override
   String languageSettingsSystemDescription(String language) {
-    return 'Following your phone language: $language.';
+    return 'Sigue el idioma del teléfono: $language.';
   }
 
   @override
   String get languageSettingsOverrideDescription =>
-      'Use this language instead of the phone language.';
+      'Usar este idioma en lugar del idioma del teléfono.';
 
   @override
-  String get darkModeLabel => 'Dark mode';
+  String get darkModeLabel => 'Modo oscuro';
 
   @override
-  String get darkModeSettingsDescription => 'Use a darker interface.';
+  String get darkModeSettingsDescription => 'Usar una interfaz más oscura.';
 
   @override
-  String get enableConfettiLabel => 'Confetti';
+  String get enableConfettiLabel => 'Confeti';
 
   @override
   String get enableConfettiSettingsDescription =>
-      'Show a celebration when you complete a bingo.';
+      'Mostrar una celebración al completar un bingo.';
 
   @override
   String get preMadeTilesTitle => 'Pre-made tiles';
@@ -349,23 +349,23 @@ class AppLocalizationsEn extends AppLocalizations {
   String get paywallCouldNotLoad => 'Could not load purchase information.';
 
   @override
-  String get shareTitle => 'Share the bingo card';
+  String get shareTitle => 'Compartir la tarjeta de bingo';
 
   @override
   String get shareDialogPrompt => 'How would you like to share?';
 
   @override
-  String get shareImageOptionTitle => 'Share as image';
+  String get shareImageOptionTitle => 'Compartir como imagen';
 
   @override
   String get shareImageOptionHelper =>
       'Send a picture of your card. Anyone can see it — even without the app.';
 
   @override
-  String get shareImageOptionButton => 'Share image';
+  String get shareImageOptionButton => 'Compartir imagen';
 
   @override
-  String get shareInviteOptionTitle => 'Invite friends to play';
+  String get shareInviteOptionTitle => 'Invitar amigos a jugar';
 
   @override
   String get shareInviteOptionHelper =>
@@ -379,15 +379,15 @@ class AppLocalizationsEn extends AppLocalizations {
       'When on, your friends will see what you\'ve already crossed off.';
 
   @override
-  String get shareInviteOptionButton => 'Send invite';
+  String get shareInviteOptionButton => 'Enviar invitación';
 
   @override
   String shareInviteText(String name, String link) {
-    return 'Play \"$name\" with me! Open it in the app:\n$link';
+    return '¡Juega “$name” conmigo! Ábrelo en la app:\n$link';
   }
 
   @override
-  String get close => 'Close';
+  String get close => 'Cerrar';
 
   @override
   String get shareSubject => 'Bingo Card';
@@ -399,10 +399,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get importBody => 'Add it to your cards so you can play along?';
 
   @override
-  String get importConfirm => 'Add to my cards';
+  String get importConfirm => 'Añadir a mis tarjetas';
 
   @override
-  String get importCancel => 'Not now';
+  String get importCancel => 'Ahora no';
 
   @override
   String importCollisionToast(String newName) {
@@ -417,20 +417,20 @@ class AppLocalizationsEn extends AppLocalizations {
   String get importOutdatedAppToast => 'Update the app to open this invite.';
 
   @override
-  String get toastInfo => 'Info';
+  String get toastInfo => 'Información';
 
   @override
-  String get toastSuccess => 'Success';
+  String get toastSuccess => 'Éxito';
 
   @override
   String get toastError => 'Error';
 
   @override
-  String get lastChangeNever => 'Last change: Never';
+  String get lastChangeNever => 'Último cambio: nunca';
 
   @override
   String lastChange(String date, String time) {
-    return 'Last change: $date $time';
+    return 'Último cambio: $date $time';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -1,0 +1,479 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for French (`fr`).
+class AppLocalizationsFr extends AppLocalizations {
+  AppLocalizationsFr([String locale = 'fr']) : super(locale);
+
+  @override
+  String get newCardTitle => 'Créer une nouvelle grille de bingo';
+
+  @override
+  String get editCardTitle => 'Modifier la grille de bingo';
+
+  @override
+  String get cardNameLabel => 'Nom de la grille *';
+
+  @override
+  String get cardNameHint => 'Donnez un nom à votre grille de bingo';
+
+  @override
+  String get createCardButton => 'Créer la grille';
+
+  @override
+  String get updateCardButton => 'Mettre à jour la grille';
+
+  @override
+  String get newBoardPreMadeSectionTitle => 'Vos éléments préparés';
+
+  @override
+  String get newBoardPreMadeButton => 'Commencer avec des éléments préparés';
+
+  @override
+  String get newBoardPreMadeChangeButton => 'Modifier les éléments préparés';
+
+  @override
+  String get newBoardPreMadeClearButton => 'Effacer les éléments préparés';
+
+  @override
+  String newBoardPreMadeAppliedCount(int count) {
+    return '$count entrées préparées appliquées';
+  }
+
+  @override
+  String newBoardPreMadeFullSummary(int used) {
+    return '$used seront tirées au hasard pour cette grille.';
+  }
+
+  @override
+  String newBoardPreMadePartialSummary(int used, int blank) {
+    return '$used cases seront remplies. $blank resteront vides.';
+  }
+
+  @override
+  String get defaultCardName => 'Carte de bingo';
+
+  @override
+  String get toggleHint => 'Appuyez longuement pour cocher une case';
+
+  @override
+  String get editingHintBefore => 'Appuyez sur l’icône de cadenas';
+
+  @override
+  String get editingHintAfter => ' pour empêcher la modification des cases.';
+
+  @override
+  String get deleteCardTitle => 'Supprimer la carte';
+
+  @override
+  String get deleteCardConfirm =>
+      'Voulez-vous vraiment supprimer cette carte ?';
+
+  @override
+  String get cancel => 'Annuler';
+
+  @override
+  String get delete => 'Supprimer';
+
+  @override
+  String get shuffleCardTitle => 'Mélanger la carte';
+
+  @override
+  String get shuffleCardConfirm =>
+      'Voulez-vous vraiment mélanger cette carte ? Toutes les cases seront décochées après le mélange.';
+
+  @override
+  String get shuffle => 'Mélanger';
+
+  @override
+  String get ratingPromptTitle => 'Do you like Custom Bingo?';
+
+  @override
+  String get ratingPromptBody =>
+      'If so, a quick store review helps others find it.';
+
+  @override
+  String get ratingPromptNo => 'Not really';
+
+  @override
+  String get ratingPromptYes => 'Yes, I like it';
+
+  @override
+  String get boardActionShare => 'Partager';
+
+  @override
+  String get boardActionEditBoard => 'Modifier la grille';
+
+  @override
+  String get boardActionAddPreMadeItems => 'Add pre-made items';
+
+  @override
+  String get cellHint => 'Saisir du texte…';
+
+  @override
+  String get edit => 'Modifier';
+
+  @override
+  String get markDone => 'Marquer comme fait';
+
+  @override
+  String get markNotDone => 'Retirer la marque';
+
+  @override
+  String get newCardMenuItem => 'Nouvelle grille de bingo';
+
+  @override
+  String get yourCardsHeader => 'Vos grilles';
+
+  @override
+  String get settingsHeader => 'Réglages';
+
+  @override
+  String get appearanceMenuItem => 'Apparence';
+
+  @override
+  String get settingsAppearanceSection => 'Apparence';
+
+  @override
+  String get settingsPreferencesSection => 'Préférences';
+
+  @override
+  String get settingsBoardsSection => 'Grilles';
+
+  @override
+  String get settingsHelpSection => 'Plus';
+
+  @override
+  String get settingsSupportSection => 'Soutien';
+
+  @override
+  String get themeColorLabel => 'Couleur du thème';
+
+  @override
+  String get themeColorSettingsDescription =>
+      'Choisissez la palette utilisée dans toute l’app.';
+
+  @override
+  String get languageSettingsTitle => 'Langue';
+
+  @override
+  String get languageSettingsSelectorLabel => 'Langue de l’app';
+
+  @override
+  String languageSettingsSystemOption(String language) {
+    return 'Par défaut du système ($language)';
+  }
+
+  @override
+  String languageSettingsSystemDescription(String language) {
+    return 'Suit la langue de votre téléphone : $language.';
+  }
+
+  @override
+  String get languageSettingsOverrideDescription =>
+      'Utiliser cette langue au lieu de celle du téléphone.';
+
+  @override
+  String get darkModeLabel => 'Mode sombre';
+
+  @override
+  String get darkModeSettingsDescription =>
+      'Utiliser une interface plus sombre.';
+
+  @override
+  String get enableConfettiLabel => 'Confettis';
+
+  @override
+  String get enableConfettiSettingsDescription =>
+      'Afficher une célébration quand vous terminez un bingo.';
+
+  @override
+  String get preMadeTilesTitle => 'Cases préparées';
+
+  @override
+  String get preMadeTilesSettingsDescription =>
+      'Créer des textes de case réutilisables pour de futures grilles.';
+
+  @override
+  String get preMadeTilesDescription =>
+      'Créez ici des entrées de bingo réutilisables. Lors de la création d’une nouvelle grille, vous pourrez les ajouter sans tout retaper.';
+
+  @override
+  String get preMadeTilesSelectMode => 'Sélectionner';
+
+  @override
+  String get preMadeTilesEditMode => 'Modifier';
+
+  @override
+  String get preMadeTileHint => 'Texte de la case';
+
+  @override
+  String get preMadeTilesAdd => 'Ajouter une case';
+
+  @override
+  String get preMadeTilesDelete => 'Supprimer la case';
+
+  @override
+  String get preMadeTilesSelectAll => 'Tout sélectionner/désélectionner';
+
+  @override
+  String get preMadeTilesSelectNone => 'Ne rien sélectionner';
+
+  @override
+  String get preMadeTilesApply => 'Appliquer';
+
+  @override
+  String get preMadeTilesReplaceItems => 'Remplacer les éléments';
+
+  @override
+  String get preMadeTilesFillItems => 'Remplir les éléments';
+
+  @override
+  String get preMadeTilesBoardActionHelp =>
+      'Replace swaps the board entries with a random draw from your selection. Fill only adds items to empty tiles. On odd boards, the center tile stays in place.';
+
+  @override
+  String preMadeTilesSelectedCount(int selected, int total) {
+    return '$selected / $total selected';
+  }
+
+  @override
+  String get preMadeTilesEmptyTitle => 'Aucune case pour l’instant';
+
+  @override
+  String get preMadeTilesEmptyBody =>
+      'Ajoutez une case pour commencer une liste réutilisable.';
+
+  @override
+  String get proposeFeatures => 'Proposer des fonctionnalités';
+
+  @override
+  String get proposeFeaturesSettingsDescription =>
+      'Votez pour des idées et suggérez la suite.';
+
+  @override
+  String get supportMeDirectly => 'Soutenir le développeur';
+
+  @override
+  String get supportMeDirectlySettingsDescription =>
+      'Aidez à financer le développement et à améliorer l’app.';
+
+  @override
+  String get supportCarouselProTitle => 'Support Custom Bingo';
+
+  @override
+  String get supportCarouselProSubtitle =>
+      'Unlock bonus colors and help keep the app independent.';
+
+  @override
+  String get supportCarouselRateTitle => 'Enjoying the app?';
+
+  @override
+  String get supportCarouselRateSubtitle =>
+      'A quick review helps more people find Custom Bingo.';
+
+  @override
+  String get rateTheApp => 'Noter l’app';
+
+  @override
+  String get rateTheAppSettingsDescription =>
+      'Ouvrir la demande de note du store.';
+
+  @override
+  String get contactMe => 'Me contacter';
+
+  @override
+  String get contactMeSettingsDescription =>
+      'Envoyer des retours, questions ou bugs par e-mail.';
+
+  @override
+  String get paywallTitle => 'Support Custom Bingo';
+
+  @override
+  String get paywallThankYouTitle => 'Thank you';
+
+  @override
+  String get paywallSupportTitle => 'Support Custom Bingo';
+
+  @override
+  String get paywallSupportBody =>
+      'This purchase supports me, the developer, directly. You get my gratitude and a few small bonus things for your boards.';
+
+  @override
+  String get paywallBonusGratitude => 'My gratitude, sincerely.';
+
+  @override
+  String get paywallBonusColors => 'A few extra board colors.';
+
+  @override
+  String get paywallBonusExtras => 'Small supporter extras over time.';
+
+  @override
+  String get paywallFreeForever =>
+      'No one ever needs to pay for this app. Custom Bingo stays usable for everyone.';
+
+  @override
+  String get paywallLoadingPrice => 'Loading price';
+
+  @override
+  String get paywallUnavailable => 'Unavailable';
+
+  @override
+  String get paywallSupportOnce => 'Support once';
+
+  @override
+  String get paywallRestorePurchase => 'Restore purchase';
+
+  @override
+  String get paywallProActiveToast => 'Custom Bingo Pro is active.';
+
+  @override
+  String get paywallPurchaseInactiveToast =>
+      'Purchase finished, but Pro is not active.';
+
+  @override
+  String get paywallProRestoredToast => 'Custom Bingo Pro restored.';
+
+  @override
+  String get paywallNoPurchaseFoundToast => 'No Pro purchase found.';
+
+  @override
+  String get paywallPurchasesUnavailable =>
+      'Purchases are unavailable right now.';
+
+  @override
+  String get paywallPlatformUnavailable =>
+      'Purchases are unavailable on this platform.';
+
+  @override
+  String get paywallCouldNotLoad => 'Could not load purchase information.';
+
+  @override
+  String get shareTitle => 'Partager la carte de bingo';
+
+  @override
+  String get shareDialogPrompt => 'Comment voulez-vous partager ?';
+
+  @override
+  String get shareImageOptionTitle => 'Partager en image';
+
+  @override
+  String get shareImageOptionHelper =>
+      'Envoyez une image de votre carte. Tout le monde peut la voir, même sans l’app.';
+
+  @override
+  String get shareImageOptionButton => 'Partager l’image';
+
+  @override
+  String get shareInviteOptionTitle => 'Inviter des amis à jouer';
+
+  @override
+  String get shareInviteOptionHelper =>
+      'Send this link to your friends who also have this app installed. They get the same card and you can play together.';
+
+  @override
+  String get shareInviteIncludeMarks => 'Inclure mes coches';
+
+  @override
+  String get shareInviteIncludeMarksHelper =>
+      'Activé, vos amis verront ce que vous avez déjà coché.';
+
+  @override
+  String get shareInviteOptionButton => 'Envoyer l’invitation';
+
+  @override
+  String shareInviteText(String name, String link) {
+    return 'Joue à « $name » avec moi ! Ouvre-le dans l’app :\n$link';
+  }
+
+  @override
+  String get close => 'Fermer';
+
+  @override
+  String get shareSubject => 'Carte de bingo';
+
+  @override
+  String get importTitle => 'Un ami vous a partagé une carte de bingo';
+
+  @override
+  String get importBody => 'L’ajouter à vos cartes pour jouer avec lui ?';
+
+  @override
+  String get importConfirm => 'Ajouter à mes cartes';
+
+  @override
+  String get importCancel => 'Pas maintenant';
+
+  @override
+  String importCollisionToast(String newName) {
+    return 'You already had a card with this name, so I added it as \"$newName\".';
+  }
+
+  @override
+  String get importBadLinkToast =>
+      'Sorry, this invite couldn\'t be opened. Ask your friend to send it again.';
+
+  @override
+  String get importOutdatedAppToast => 'Update the app to open this invite.';
+
+  @override
+  String get toastInfo => 'Info';
+
+  @override
+  String get toastSuccess => 'Succès';
+
+  @override
+  String get toastError => 'Erreur';
+
+  @override
+  String get lastChangeNever => 'Dernière modification : jamais';
+
+  @override
+  String lastChange(String date, String time) {
+    return 'Dernière modification : $date $time';
+  }
+
+  @override
+  String get screenshotCaptionPlaying =>
+      'Une app toute simple pour créer une grille de bingo.\n\nSans inscription, sans pub, entièrement gratuite.';
+
+  @override
+  String get screenshotCaptionCreate =>
+      'Seulement deux écrans pour créer une grille de bingo.';
+
+  @override
+  String get screenshotCaptionLocked => 'C’est tout.';
+
+  @override
+  String get screenshotBoardName => 'Mariage de David';
+
+  @override
+  String get screenshotTilePhoneDuringVows => 'Téléphone pendant les vœux';
+
+  @override
+  String get screenshotTileChampagneSpilled => 'Champagne renversé';
+
+  @override
+  String get screenshotTileSpeechTears => 'Larmes pendant le discours';
+
+  @override
+  String get screenshotTileDramaticEntrance => 'Entrée théâtrale';
+
+  @override
+  String get screenshotTileKidsDanceFloor => 'Les enfants envahissent la piste';
+
+  @override
+  String get screenshotTileGuestToast => 'Un invité porte un toast';
+
+  @override
+  String get screenshotTileCrowdClapsEarly => 'Applaudissements trop tôt';
+
+  @override
+  String get screenshotTileDjClassic => 'Le DJ met un classique';
+
+  @override
+  String get screenshotTileGroupPhotoChaos => 'Chaos pour la photo de groupe';
+}

--- a/lib/l10n/arb/app_localizations_fr.dart
+++ b/lib/l10n/arb/app_localizations_fr.dart
@@ -89,17 +89,17 @@ class AppLocalizationsFr extends AppLocalizations {
   String get shuffle => 'Mélanger';
 
   @override
-  String get ratingPromptTitle => 'Do you like Custom Bingo?';
+  String get ratingPromptTitle => 'Vous aimez Custom Bingo ?';
 
   @override
   String get ratingPromptBody =>
-      'If so, a quick store review helps others find it.';
+      'Si oui, un avis rapide sur le store aide d’autres personnes à le trouver.';
 
   @override
-  String get ratingPromptNo => 'Not really';
+  String get ratingPromptNo => 'Pas vraiment';
 
   @override
-  String get ratingPromptYes => 'Yes, I like it';
+  String get ratingPromptYes => 'Oui, j’aime';
 
   @override
   String get boardActionShare => 'Partager';
@@ -108,7 +108,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get boardActionEditBoard => 'Modifier la grille';
 
   @override
-  String get boardActionAddPreMadeItems => 'Add pre-made items';
+  String get boardActionAddPreMadeItems => 'Ajouter des éléments préparés';
 
   @override
   String get cellHint => 'Saisir du texte…';
@@ -126,10 +126,37 @@ class AppLocalizationsFr extends AppLocalizations {
   String get newCardMenuItem => 'Nouvelle grille de bingo';
 
   @override
+  String get allBoardsMenuItem => 'Toutes les grilles';
+
+  @override
   String get yourCardsHeader => 'Vos grilles';
 
   @override
+  String get noBoardsYet => 'Aucune grille pour l’instant';
+
+  @override
+  String get pageNotFoundTitle => 'Page introuvable';
+
+  @override
+  String get homeButton => 'Accueil';
+
+  @override
+  String revenueCatUserIdLabel(String userId) {
+    return 'ID utilisateur RevenueCat : $userId';
+  }
+
+  @override
+  String get copyRevenueCatUserIdTooltip =>
+      'Copier l’ID utilisateur RevenueCat';
+
+  @override
+  String get revenueCatUserIdCopiedToast => 'ID utilisateur RevenueCat copié.';
+
+  @override
   String get settingsHeader => 'Réglages';
+
+  @override
+  String get clearSettingsMenuItem => 'Effacer les réglages';
 
   @override
   String get appearanceMenuItem => 'Apparence';
@@ -233,11 +260,11 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get preMadeTilesBoardActionHelp =>
-      'Replace swaps the board entries with a random draw from your selection. Fill only adds items to empty tiles. On odd boards, the center tile stays in place.';
+      'Remplacer échange les entrées de la grille contre un tirage aléatoire de votre sélection. Remplir ajoute seulement des éléments aux cases vides. Sur les grilles impaires, la case centrale reste en place.';
 
   @override
   String preMadeTilesSelectedCount(int selected, int total) {
-    return '$selected / $total selected';
+    return '$selected / $total sélectionnées';
   }
 
   @override
@@ -262,18 +289,18 @@ class AppLocalizationsFr extends AppLocalizations {
       'Aidez à financer le développement et à améliorer l’app.';
 
   @override
-  String get supportCarouselProTitle => 'Support Custom Bingo';
+  String get supportCarouselProTitle => 'Soutenir Custom Bingo';
 
   @override
   String get supportCarouselProSubtitle =>
-      'Unlock bonus colors and help keep the app independent.';
+      'Débloquez des couleurs bonus et aidez l’app à rester indépendante.';
 
   @override
-  String get supportCarouselRateTitle => 'Enjoying the app?';
+  String get supportCarouselRateTitle => 'Vous aimez l’app ?';
 
   @override
   String get supportCarouselRateSubtitle =>
-      'A quick review helps more people find Custom Bingo.';
+      'Un avis rapide aide plus de personnes à découvrir Custom Bingo.';
 
   @override
   String get rateTheApp => 'Noter l’app';
@@ -290,66 +317,68 @@ class AppLocalizationsFr extends AppLocalizations {
       'Envoyer des retours, questions ou bugs par e-mail.';
 
   @override
-  String get paywallTitle => 'Support Custom Bingo';
+  String get paywallTitle => 'Soutenir Custom Bingo';
 
   @override
-  String get paywallThankYouTitle => 'Thank you';
+  String get paywallThankYouTitle => 'Merci';
 
   @override
-  String get paywallSupportTitle => 'Support Custom Bingo';
+  String get paywallSupportTitle => 'Soutenir Custom Bingo';
 
   @override
   String get paywallSupportBody =>
-      'This purchase supports me, the developer, directly. You get my gratitude and a few small bonus things for your boards.';
+      'Cet achat me soutient directement, moi le développeur. Vous recevez ma gratitude et quelques petits bonus pour vos grilles.';
 
   @override
-  String get paywallBonusGratitude => 'My gratitude, sincerely.';
+  String get paywallBonusGratitude => 'Ma gratitude, sincèrement.';
 
   @override
-  String get paywallBonusColors => 'A few extra board colors.';
+  String get paywallBonusColors => 'Quelques couleurs de grille en plus.';
 
   @override
-  String get paywallBonusExtras => 'Small supporter extras over time.';
+  String get paywallBonusExtras =>
+      'De petits bonus de soutien au fil du temps.';
 
   @override
   String get paywallFreeForever =>
-      'No one ever needs to pay for this app. Custom Bingo stays usable for everyone.';
+      'Personne n’a jamais besoin de payer pour cette app. Custom Bingo reste utilisable par tout le monde.';
 
   @override
-  String get paywallLoadingPrice => 'Loading price';
+  String get paywallLoadingPrice => 'Chargement du prix';
 
   @override
-  String get paywallUnavailable => 'Unavailable';
+  String get paywallUnavailable => 'Indisponible';
 
   @override
-  String get paywallSupportOnce => 'Support once';
+  String get paywallSupportOnce => 'Soutenir une fois';
 
   @override
-  String get paywallRestorePurchase => 'Restore purchase';
+  String get paywallRestorePurchase => 'Restaurer l’achat';
 
   @override
-  String get paywallProActiveToast => 'Custom Bingo Pro is active.';
+  String get paywallProActiveToast => 'Custom Bingo Pro est actif.';
 
   @override
   String get paywallPurchaseInactiveToast =>
-      'Purchase finished, but Pro is not active.';
+      'L’achat est terminé, mais Pro n’est pas actif.';
 
   @override
-  String get paywallProRestoredToast => 'Custom Bingo Pro restored.';
+  String get paywallProRestoredToast => 'Custom Bingo Pro restauré.';
 
   @override
-  String get paywallNoPurchaseFoundToast => 'No Pro purchase found.';
+  String get paywallNoPurchaseFoundToast => 'Aucun achat Pro trouvé.';
 
   @override
   String get paywallPurchasesUnavailable =>
-      'Purchases are unavailable right now.';
+      'Les achats sont indisponibles pour le moment.';
 
   @override
   String get paywallPlatformUnavailable =>
-      'Purchases are unavailable on this platform.';
+      'Les achats ne sont pas disponibles sur cette plateforme.';
 
   @override
-  String get paywallCouldNotLoad => 'Could not load purchase information.';
+  String get paywallCouldNotLoad =>
+      'Impossible de charger les informations d’achat.';
 
   @override
   String get shareTitle => 'Partager la carte de bingo';
@@ -372,7 +401,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get shareInviteOptionHelper =>
-      'Send this link to your friends who also have this app installed. They get the same card and you can play together.';
+      'Envoyez ce lien à vos amis qui ont aussi installé cette app. Ils recevront la même carte et vous pourrez jouer ensemble.';
 
   @override
   String get shareInviteIncludeMarks => 'Inclure mes coches';
@@ -409,18 +438,19 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String importCollisionToast(String newName) {
-    return 'You already had a card with this name, so I added it as \"$newName\".';
+    return 'Vous aviez déjà une carte avec ce nom, je l’ai donc ajoutée sous « $newName ».';
   }
 
   @override
   String get importBadLinkToast =>
-      'Sorry, this invite couldn\'t be opened. Ask your friend to send it again.';
+      'Désolé, cette invitation n’a pas pu être ouverte. Demandez à votre ami de la renvoyer.';
 
   @override
-  String get importOutdatedAppToast => 'Update the app to open this invite.';
+  String get importOutdatedAppToast =>
+      'Mettez l’app à jour pour ouvrir cette invitation.';
 
   @override
-  String get toastInfo => 'Info';
+  String get toastInfo => 'Information';
 
   @override
   String get toastSuccess => 'Succès';

--- a/lib/l10n/arb/app_localizations_ja.dart
+++ b/lib/l10n/arb/app_localizations_ja.dart
@@ -27,30 +27,30 @@ class AppLocalizationsJa extends AppLocalizations {
   String get updateCardButton => 'ビンゴ表を更新';
 
   @override
-  String get newBoardPreMadeSectionTitle => 'Your pre-made items';
+  String get newBoardPreMadeSectionTitle => '作成済み項目';
 
   @override
-  String get newBoardPreMadeButton => 'Start with pre-made items';
+  String get newBoardPreMadeButton => '作成済み項目から始める';
 
   @override
-  String get newBoardPreMadeChangeButton => 'Change pre-made items';
+  String get newBoardPreMadeChangeButton => '作成済み項目を変更';
 
   @override
-  String get newBoardPreMadeClearButton => 'Clear pre-made items';
+  String get newBoardPreMadeClearButton => '作成済み項目をクリア';
 
   @override
   String newBoardPreMadeAppliedCount(int count) {
-    return '$count pre-made entries applied';
+    return '$count 件の作成済み項目を適用しました';
   }
 
   @override
   String newBoardPreMadeFullSummary(int used) {
-    return '$used will be drawn at random for this board.';
+    return 'このボードには $used 件がランダムに選ばれます。';
   }
 
   @override
   String newBoardPreMadePartialSummary(int used, int blank) {
-    return '$used cells will be filled. $blank will stay blank.';
+    return '$used マスが埋まります。$blank マスは空のままです。';
   }
 
   @override
@@ -60,16 +60,16 @@ class AppLocalizationsJa extends AppLocalizations {
   String get toggleHint => '長押しでマスをチェック';
 
   @override
-  String get editingHintBefore => 'Press the lock icon';
+  String get editingHintBefore => 'ロックアイコンを押すと';
 
   @override
-  String get editingHintAfter => ' to make the fields not editable anymore.';
+  String get editingHintAfter => '、マスを編集できないようにできます。';
 
   @override
-  String get deleteCardTitle => 'Delete Card';
+  String get deleteCardTitle => 'カードを削除';
 
   @override
-  String get deleteCardConfirm => 'Are you sure you want to delete this card?';
+  String get deleteCardConfirm => 'このカードを削除してもよろしいですか？';
 
   @override
   String get cancel => 'キャンセル';
@@ -78,27 +78,26 @@ class AppLocalizationsJa extends AppLocalizations {
   String get delete => '削除';
 
   @override
-  String get shuffleCardTitle => 'Shuffle Card';
+  String get shuffleCardTitle => 'カードをシャッフル';
 
   @override
   String get shuffleCardConfirm =>
-      'Are you sure you want to shuffle this card? All fields will be unchecked, after shuffling.';
+      'このカードをシャッフルしてもよろしいですか？シャッフル後、すべてのマスのチェックが外れます。';
 
   @override
   String get shuffle => 'シャッフル';
 
   @override
-  String get ratingPromptTitle => 'Do you like Custom Bingo?';
+  String get ratingPromptTitle => 'Custom Bingo は気に入りましたか？';
 
   @override
-  String get ratingPromptBody =>
-      'If so, a quick store review helps others find it.';
+  String get ratingPromptBody => 'よろしければ、ストアでの短いレビューが他の人の発見につながります。';
 
   @override
-  String get ratingPromptNo => 'Not really';
+  String get ratingPromptNo => 'あまり';
 
   @override
-  String get ratingPromptYes => 'Yes, I like it';
+  String get ratingPromptYes => 'はい、気に入りました';
 
   @override
   String get boardActionShare => '共有';
@@ -107,7 +106,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get boardActionEditBoard => 'ボードを編集';
 
   @override
-  String get boardActionAddPreMadeItems => 'Add pre-made items';
+  String get boardActionAddPreMadeItems => '作成済み項目を追加';
 
   @override
   String get cellHint => 'テキストを入力…';
@@ -116,22 +115,48 @@ class AppLocalizationsJa extends AppLocalizations {
   String get edit => '編集';
 
   @override
-  String get markDone => 'Mark Done';
+  String get markDone => '完了にする';
 
   @override
-  String get markNotDone => 'Mark Not Done';
+  String get markNotDone => '未完了にする';
 
   @override
   String get newCardMenuItem => '新しいビンゴボード';
 
   @override
+  String get allBoardsMenuItem => 'すべてのボード';
+
+  @override
   String get yourCardsHeader => 'あなたのボード';
+
+  @override
+  String get noBoardsYet => 'ボードはまだありません';
+
+  @override
+  String get pageNotFoundTitle => 'ページが見つかりません';
+
+  @override
+  String get homeButton => 'ホーム';
+
+  @override
+  String revenueCatUserIdLabel(String userId) {
+    return 'RevenueCat ユーザーID: $userId';
+  }
+
+  @override
+  String get copyRevenueCatUserIdTooltip => 'RevenueCat ユーザーIDをコピー';
+
+  @override
+  String get revenueCatUserIdCopiedToast => 'RevenueCat ユーザーIDをコピーしました。';
 
   @override
   String get settingsHeader => '設定';
 
   @override
-  String get appearanceMenuItem => 'Appearance';
+  String get clearSettingsMenuItem => '設定をクリア';
+
+  @override
+  String get appearanceMenuItem => '外観';
 
   @override
   String get settingsAppearanceSection => '外観';
@@ -186,177 +211,168 @@ class AppLocalizationsJa extends AppLocalizations {
   String get enableConfettiSettingsDescription => 'ビンゴ達成時にお祝いを表示します。';
 
   @override
-  String get preMadeTilesTitle => 'Pre-made tiles';
+  String get preMadeTilesTitle => '作成済みタイル';
 
   @override
-  String get preMadeTilesSettingsDescription =>
-      'Create reusable tile text for future boards.';
+  String get preMadeTilesSettingsDescription => '今後のボードで使えるタイル文を作成します。';
 
   @override
   String get preMadeTilesDescription =>
-      'Create reusable bingo entries here. When you create a new board, you can add them without typing everything again.';
+      '再利用できるビンゴ項目をここで作成します。新しいボードを作るとき、入力し直さずに追加できます。';
 
   @override
-  String get preMadeTilesSelectMode => 'Select';
+  String get preMadeTilesSelectMode => '選択';
 
   @override
-  String get preMadeTilesEditMode => 'Edit';
+  String get preMadeTilesEditMode => '編集';
 
   @override
-  String get preMadeTileHint => 'Tile text';
+  String get preMadeTileHint => 'タイルのテキスト';
 
   @override
-  String get preMadeTilesAdd => 'Add tile';
+  String get preMadeTilesAdd => 'タイルを追加';
 
   @override
-  String get preMadeTilesDelete => 'Delete tile';
+  String get preMadeTilesDelete => 'タイルを削除';
 
   @override
-  String get preMadeTilesSelectAll => 'Un/select all';
+  String get preMadeTilesSelectAll => 'すべて選択/解除';
 
   @override
-  String get preMadeTilesSelectNone => 'Select none';
+  String get preMadeTilesSelectNone => '選択を解除';
 
   @override
-  String get preMadeTilesApply => 'Apply';
+  String get preMadeTilesApply => '適用';
 
   @override
-  String get preMadeTilesReplaceItems => 'Replace items';
+  String get preMadeTilesReplaceItems => '項目を置き換え';
 
   @override
-  String get preMadeTilesFillItems => 'Fill items';
+  String get preMadeTilesFillItems => '項目を埋める';
 
   @override
   String get preMadeTilesBoardActionHelp =>
-      'Replace swaps the board entries with a random draw from your selection. Fill only adds items to empty tiles. On odd boards, the center tile stays in place.';
+      '置き換えは、選択内容からランダムに引いた項目でボードを入れ替えます。埋めるは空のタイルにだけ項目を追加します。奇数サイズのボードでは中央タイルはそのままです。';
 
   @override
   String preMadeTilesSelectedCount(int selected, int total) {
-    return '$selected / $total selected';
+    return '$selected / $total 選択済み';
   }
 
   @override
-  String get preMadeTilesEmptyTitle => 'No tiles yet';
+  String get preMadeTilesEmptyTitle => 'タイルはまだありません';
 
   @override
-  String get preMadeTilesEmptyBody =>
-      'Add a tile to start building a reusable list.';
+  String get preMadeTilesEmptyBody => 'タイルを追加して、再利用できるリストを作り始めましょう。';
 
   @override
-  String get proposeFeatures => 'Propose Features';
+  String get proposeFeatures => '機能を提案';
 
   @override
-  String get proposeFeaturesSettingsDescription =>
-      'Vote on ideas and suggest what to build next.';
+  String get proposeFeaturesSettingsDescription => 'アイデアに投票して、次に作るものを提案します。';
 
   @override
-  String get supportMeDirectly => 'Support the developer';
+  String get supportMeDirectly => '開発者を支援';
 
   @override
   String get supportMeDirectlySettingsDescription =>
-      'Help fund development and keep the app improving.';
+      '開発資金を支援し、アプリの改善を続けられるようにします。';
 
   @override
-  String get supportCarouselProTitle => 'Support Custom Bingo';
+  String get supportCarouselProTitle => 'Custom Bingo を支援';
 
   @override
-  String get supportCarouselProSubtitle =>
-      'Unlock bonus colors and help keep the app independent.';
+  String get supportCarouselProSubtitle => '追加カラーを解除し、アプリの独立運営を支援します。';
 
   @override
-  String get supportCarouselRateTitle => 'Enjoying the app?';
+  String get supportCarouselRateTitle => 'アプリを楽しんでいますか？';
 
   @override
   String get supportCarouselRateSubtitle =>
-      'A quick review helps more people find Custom Bingo.';
+      '短いレビューが、より多くの人に Custom Bingo を見つけてもらう助けになります。';
 
   @override
-  String get rateTheApp => 'Rate the app';
+  String get rateTheApp => 'アプリを評価';
 
   @override
-  String get rateTheAppSettingsDescription => 'Open the store rating prompt.';
+  String get rateTheAppSettingsDescription => 'ストア評価の案内を開きます。';
 
   @override
-  String get contactMe => 'Contact me';
+  String get contactMe => '問い合わせる';
 
   @override
-  String get contactMeSettingsDescription =>
-      'Send feedback, questions, or bug reports by email.';
+  String get contactMeSettingsDescription => '感想、質問、不具合報告をメールで送ります。';
 
   @override
-  String get paywallTitle => 'Support Custom Bingo';
+  String get paywallTitle => 'Custom Bingo を支援';
 
   @override
-  String get paywallThankYouTitle => 'Thank you';
+  String get paywallThankYouTitle => 'ありがとうございます';
 
   @override
-  String get paywallSupportTitle => 'Support Custom Bingo';
+  String get paywallSupportTitle => 'Custom Bingo を支援';
 
   @override
   String get paywallSupportBody =>
-      'This purchase supports me, the developer, directly. You get my gratitude and a few small bonus things for your boards.';
+      'この購入は開発者である私を直接支援します。感謝の気持ちと、ボード用の小さな追加要素を受け取れます。';
 
   @override
-  String get paywallBonusGratitude => 'My gratitude, sincerely.';
+  String get paywallBonusGratitude => '心からの感謝。';
 
   @override
-  String get paywallBonusColors => 'A few extra board colors.';
+  String get paywallBonusColors => 'ボード用の追加カラー。';
 
   @override
-  String get paywallBonusExtras => 'Small supporter extras over time.';
+  String get paywallBonusExtras => '支援者向けの小さな追加要素。';
 
   @override
   String get paywallFreeForever =>
-      'No one ever needs to pay for this app. Custom Bingo stays usable for everyone.';
+      'このアプリに支払いは必須ではありません。Custom Bingo は誰でも使い続けられます。';
 
   @override
-  String get paywallLoadingPrice => 'Loading price';
+  String get paywallLoadingPrice => '価格を読み込み中';
 
   @override
-  String get paywallUnavailable => 'Unavailable';
+  String get paywallUnavailable => '利用できません';
 
   @override
-  String get paywallSupportOnce => 'Support once';
+  String get paywallSupportOnce => '一度支援する';
 
   @override
-  String get paywallRestorePurchase => 'Restore purchase';
+  String get paywallRestorePurchase => '購入を復元';
 
   @override
-  String get paywallProActiveToast => 'Custom Bingo Pro is active.';
+  String get paywallProActiveToast => 'Custom Bingo Pro が有効です。';
 
   @override
-  String get paywallPurchaseInactiveToast =>
-      'Purchase finished, but Pro is not active.';
+  String get paywallPurchaseInactiveToast => '購入は完了しましたが、Pro は有効ではありません。';
 
   @override
-  String get paywallProRestoredToast => 'Custom Bingo Pro restored.';
+  String get paywallProRestoredToast => 'Custom Bingo Pro を復元しました。';
 
   @override
-  String get paywallNoPurchaseFoundToast => 'No Pro purchase found.';
+  String get paywallNoPurchaseFoundToast => 'Pro の購入は見つかりませんでした。';
 
   @override
-  String get paywallPurchasesUnavailable =>
-      'Purchases are unavailable right now.';
+  String get paywallPurchasesUnavailable => '現在、購入は利用できません。';
 
   @override
-  String get paywallPlatformUnavailable =>
-      'Purchases are unavailable on this platform.';
+  String get paywallPlatformUnavailable => 'このプラットフォームでは購入を利用できません。';
 
   @override
-  String get paywallCouldNotLoad => 'Could not load purchase information.';
+  String get paywallCouldNotLoad => '購入情報を読み込めませんでした。';
 
   @override
   String get shareTitle => 'ビンゴカードを共有';
 
   @override
-  String get shareDialogPrompt => 'How would you like to share?';
+  String get shareDialogPrompt => 'どのように共有しますか？';
 
   @override
   String get shareImageOptionTitle => '画像として共有';
 
   @override
-  String get shareImageOptionHelper =>
-      'Send a picture of your card. Anyone can see it — even without the app.';
+  String get shareImageOptionHelper => 'カードの画像を送ります。アプリがなくても誰でも見られます。';
 
   @override
   String get shareImageOptionButton => '画像を共有';
@@ -366,14 +382,14 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get shareInviteOptionHelper =>
-      'Send this link to your friends who also have this app installed. They get the same card and you can play together.';
+      'このアプリをインストールしている友達にリンクを送ります。同じカードを受け取って一緒に遊べます。';
 
   @override
-  String get shareInviteIncludeMarks => 'Include my checkmarks';
+  String get shareInviteIncludeMarks => '自分のチェックを含める';
 
   @override
   String get shareInviteIncludeMarksHelper =>
-      'When on, your friends will see what you\'ve already crossed off.';
+      'オンにすると、友達はあなたがすでにチェックした項目を見られます。';
 
   @override
   String get shareInviteOptionButton => '招待を送信';
@@ -387,13 +403,13 @@ class AppLocalizationsJa extends AppLocalizations {
   String get close => '閉じる';
 
   @override
-  String get shareSubject => 'Bingo Card';
+  String get shareSubject => 'ビンゴカード';
 
   @override
-  String get importTitle => 'A friend shared a bingo card with you';
+  String get importTitle => '友達がビンゴカードを共有しました';
 
   @override
-  String get importBody => 'Add it to your cards so you can play along?';
+  String get importBody => '一緒に遊ぶためにカードに追加しますか？';
 
   @override
   String get importConfirm => '自分のカードに追加';
@@ -403,15 +419,14 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String importCollisionToast(String newName) {
-    return 'You already had a card with this name, so I added it as \"$newName\".';
+    return '同じ名前のカードが既にあったため、「$newName」として追加しました。';
   }
 
   @override
-  String get importBadLinkToast =>
-      'Sorry, this invite couldn\'t be opened. Ask your friend to send it again.';
+  String get importBadLinkToast => 'この招待を開けませんでした。友達にもう一度送ってもらってください。';
 
   @override
-  String get importOutdatedAppToast => 'Update the app to open this invite.';
+  String get importOutdatedAppToast => 'この招待を開くにはアプリを更新してください。';
 
   @override
   String get toastInfo => '情報';
@@ -432,42 +447,41 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get screenshotCaptionPlaying =>
-      'Just a simple app to create bingo board.\n\nNo signup, no ads, fully free to use.';
+      'ビンゴボードを作るためのシンプルなアプリ。\\n\\n登録なし、広告なし、完全無料。';
 
   @override
-  String get screenshotCaptionCreate =>
-      'Literally just 2 screens to create a bingo grid.';
+  String get screenshotCaptionCreate => 'ビンゴグリッド作成はたった2画面。';
 
   @override
-  String get screenshotCaptionLocked => 'That\'s it.';
+  String get screenshotCaptionLocked => 'これだけです。';
 
   @override
-  String get screenshotBoardName => 'David\'s Wedding';
+  String get screenshotBoardName => 'デイビッドの結婚式';
 
   @override
-  String get screenshotTilePhoneDuringVows => 'Phone during vows';
+  String get screenshotTilePhoneDuringVows => '誓いの最中に電話';
 
   @override
-  String get screenshotTileChampagneSpilled => 'Champagne spilled';
+  String get screenshotTileChampagneSpilled => 'シャンパンがこぼれる';
 
   @override
-  String get screenshotTileSpeechTears => 'Speech tears';
+  String get screenshotTileSpeechTears => 'スピーチで涙';
 
   @override
-  String get screenshotTileDramaticEntrance => 'Dramatic entrance';
+  String get screenshotTileDramaticEntrance => 'ドラマチックな入場';
 
   @override
-  String get screenshotTileKidsDanceFloor => 'Kids take the dance floor';
+  String get screenshotTileKidsDanceFloor => '子どもがダンスフロアへ';
 
   @override
-  String get screenshotTileGuestToast => 'Guest gives a toast';
+  String get screenshotTileGuestToast => 'ゲストが乾杯';
 
   @override
-  String get screenshotTileCrowdClapsEarly => 'Crowd claps early';
+  String get screenshotTileCrowdClapsEarly => '拍手が早すぎる';
 
   @override
-  String get screenshotTileDjClassic => 'DJ plays a classic';
+  String get screenshotTileDjClassic => 'DJが定番曲を流す';
 
   @override
-  String get screenshotTileGroupPhotoChaos => 'Group photo chaos';
+  String get screenshotTileGroupPhotoChaos => '集合写真が大混乱';
 }

--- a/lib/l10n/arb/app_localizations_ja.dart
+++ b/lib/l10n/arb/app_localizations_ja.dart
@@ -4,27 +4,27 @@ import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
 
-/// The translations for English (`en`).
-class AppLocalizationsEn extends AppLocalizations {
-  AppLocalizationsEn([String locale = 'en']) : super(locale);
+/// The translations for Japanese (`ja`).
+class AppLocalizationsJa extends AppLocalizations {
+  AppLocalizationsJa([String locale = 'ja']) : super(locale);
 
   @override
-  String get newCardTitle => 'Create New Bingo Grid';
+  String get newCardTitle => '新しいビンゴ表を作成';
 
   @override
-  String get editCardTitle => 'Edit Bingo Grid';
+  String get editCardTitle => 'ビンゴ表を編集';
 
   @override
-  String get cardNameLabel => 'Bingo Grid Name *';
+  String get cardNameLabel => 'ビンゴ表の名前 *';
 
   @override
-  String get cardNameHint => 'Enter a name for your bingo grid';
+  String get cardNameHint => 'ビンゴ表の名前を入力';
 
   @override
-  String get createCardButton => 'Create Bingo Grid';
+  String get createCardButton => 'ビンゴ表を作成';
 
   @override
-  String get updateCardButton => 'Update Bingo Grid';
+  String get updateCardButton => 'ビンゴ表を更新';
 
   @override
   String get newBoardPreMadeSectionTitle => 'Your pre-made items';
@@ -54,10 +54,10 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get defaultCardName => 'Bingo Card';
+  String get defaultCardName => 'ビンゴカード';
 
   @override
-  String get toggleHint => 'Press long to mark a field as checked';
+  String get toggleHint => '長押しでマスをチェック';
 
   @override
   String get editingHintBefore => 'Press the lock icon';
@@ -72,10 +72,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get deleteCardConfirm => 'Are you sure you want to delete this card?';
 
   @override
-  String get cancel => 'Cancel';
+  String get cancel => 'キャンセル';
 
   @override
-  String get delete => 'Delete';
+  String get delete => '削除';
 
   @override
   String get shuffleCardTitle => 'Shuffle Card';
@@ -85,7 +85,7 @@ class AppLocalizationsEn extends AppLocalizations {
       'Are you sure you want to shuffle this card? All fields will be unchecked, after shuffling.';
 
   @override
-  String get shuffle => 'Shuffle';
+  String get shuffle => 'シャッフル';
 
   @override
   String get ratingPromptTitle => 'Do you like Custom Bingo?';
@@ -101,19 +101,19 @@ class AppLocalizationsEn extends AppLocalizations {
   String get ratingPromptYes => 'Yes, I like it';
 
   @override
-  String get boardActionShare => 'Share';
+  String get boardActionShare => '共有';
 
   @override
-  String get boardActionEditBoard => 'Edit board';
+  String get boardActionEditBoard => 'ボードを編集';
 
   @override
   String get boardActionAddPreMadeItems => 'Add pre-made items';
 
   @override
-  String get cellHint => 'Enter text…';
+  String get cellHint => 'テキストを入力…';
 
   @override
-  String get edit => 'Edit';
+  String get edit => '編集';
 
   @override
   String get markDone => 'Mark Done';
@@ -122,71 +122,68 @@ class AppLocalizationsEn extends AppLocalizations {
   String get markNotDone => 'Mark Not Done';
 
   @override
-  String get newCardMenuItem => 'New bingo board';
+  String get newCardMenuItem => '新しいビンゴボード';
 
   @override
-  String get yourCardsHeader => 'Your Boards';
+  String get yourCardsHeader => 'あなたのボード';
 
   @override
-  String get settingsHeader => 'Settings';
+  String get settingsHeader => '設定';
 
   @override
   String get appearanceMenuItem => 'Appearance';
 
   @override
-  String get settingsAppearanceSection => 'Appearance';
+  String get settingsAppearanceSection => '外観';
 
   @override
-  String get settingsPreferencesSection => 'Preferences';
+  String get settingsPreferencesSection => '環境設定';
 
   @override
-  String get settingsBoardsSection => 'Boards';
+  String get settingsBoardsSection => 'ボード';
 
   @override
-  String get settingsHelpSection => 'More';
+  String get settingsHelpSection => 'その他';
 
   @override
-  String get settingsSupportSection => 'Support';
+  String get settingsSupportSection => 'サポート';
 
   @override
-  String get themeColorLabel => 'Theme color';
+  String get themeColorLabel => 'テーマカラー';
 
   @override
-  String get themeColorSettingsDescription =>
-      'Choose the palette used across the app.';
+  String get themeColorSettingsDescription => 'アプリ全体で使う配色を選びます。';
 
   @override
-  String get languageSettingsTitle => 'Language';
+  String get languageSettingsTitle => '言語';
 
   @override
-  String get languageSettingsSelectorLabel => 'App language';
+  String get languageSettingsSelectorLabel => 'アプリの言語';
 
   @override
   String languageSettingsSystemOption(String language) {
-    return 'System default ($language)';
+    return 'システム標準（$language）';
   }
 
   @override
   String languageSettingsSystemDescription(String language) {
-    return 'Following your phone language: $language.';
+    return '端末の言語に合わせます：$language。';
   }
 
   @override
-  String get languageSettingsOverrideDescription =>
-      'Use this language instead of the phone language.';
+  String get languageSettingsOverrideDescription => '端末の言語ではなく、この言語を使います。';
 
   @override
-  String get darkModeLabel => 'Dark mode';
+  String get darkModeLabel => 'ダークモード';
 
   @override
-  String get darkModeSettingsDescription => 'Use a darker interface.';
+  String get darkModeSettingsDescription => '暗めの画面表示を使います。';
 
   @override
-  String get enableConfettiLabel => 'Confetti';
+  String get enableConfettiLabel => '紙吹雪';
 
   @override
-  String get enableConfettiSettingsDescription =>
-      'Show a celebration when you complete a bingo.';
+  String get enableConfettiSettingsDescription => 'ビンゴ達成時にお祝いを表示します。';
 
   @override
   String get preMadeTilesTitle => 'Pre-made tiles';
@@ -349,23 +346,23 @@ class AppLocalizationsEn extends AppLocalizations {
   String get paywallCouldNotLoad => 'Could not load purchase information.';
 
   @override
-  String get shareTitle => 'Share the bingo card';
+  String get shareTitle => 'ビンゴカードを共有';
 
   @override
   String get shareDialogPrompt => 'How would you like to share?';
 
   @override
-  String get shareImageOptionTitle => 'Share as image';
+  String get shareImageOptionTitle => '画像として共有';
 
   @override
   String get shareImageOptionHelper =>
       'Send a picture of your card. Anyone can see it — even without the app.';
 
   @override
-  String get shareImageOptionButton => 'Share image';
+  String get shareImageOptionButton => '画像を共有';
 
   @override
-  String get shareInviteOptionTitle => 'Invite friends to play';
+  String get shareInviteOptionTitle => '友だちを招待して遊ぶ';
 
   @override
   String get shareInviteOptionHelper =>
@@ -379,15 +376,15 @@ class AppLocalizationsEn extends AppLocalizations {
       'When on, your friends will see what you\'ve already crossed off.';
 
   @override
-  String get shareInviteOptionButton => 'Send invite';
+  String get shareInviteOptionButton => '招待を送信';
 
   @override
   String shareInviteText(String name, String link) {
-    return 'Play \"$name\" with me! Open it in the app:\n$link';
+    return '「$name」を一緒に遊ぼう！アプリで開いてください：\n$link';
   }
 
   @override
-  String get close => 'Close';
+  String get close => '閉じる';
 
   @override
   String get shareSubject => 'Bingo Card';
@@ -399,10 +396,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get importBody => 'Add it to your cards so you can play along?';
 
   @override
-  String get importConfirm => 'Add to my cards';
+  String get importConfirm => '自分のカードに追加';
 
   @override
-  String get importCancel => 'Not now';
+  String get importCancel => '今はしない';
 
   @override
   String importCollisionToast(String newName) {
@@ -417,20 +414,20 @@ class AppLocalizationsEn extends AppLocalizations {
   String get importOutdatedAppToast => 'Update the app to open this invite.';
 
   @override
-  String get toastInfo => 'Info';
+  String get toastInfo => '情報';
 
   @override
-  String get toastSuccess => 'Success';
+  String get toastSuccess => '成功';
 
   @override
-  String get toastError => 'Error';
+  String get toastError => 'エラー';
 
   @override
-  String get lastChangeNever => 'Last change: Never';
+  String get lastChangeNever => '最終変更：なし';
 
   @override
   String lastChange(String date, String time) {
-    return 'Last change: $date $time';
+    return '最終変更：$date $time';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -4,27 +4,27 @@ import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
 
-/// The translations for English (`en`).
-class AppLocalizationsEn extends AppLocalizations {
-  AppLocalizationsEn([String locale = 'en']) : super(locale);
+/// The translations for Portuguese (`pt`).
+class AppLocalizationsPt extends AppLocalizations {
+  AppLocalizationsPt([String locale = 'pt']) : super(locale);
 
   @override
-  String get newCardTitle => 'Create New Bingo Grid';
+  String get newCardTitle => 'Criar nova cartela de bingo';
 
   @override
-  String get editCardTitle => 'Edit Bingo Grid';
+  String get editCardTitle => 'Editar cartela de bingo';
 
   @override
-  String get cardNameLabel => 'Bingo Grid Name *';
+  String get cardNameLabel => 'Nome da cartela *';
 
   @override
-  String get cardNameHint => 'Enter a name for your bingo grid';
+  String get cardNameHint => 'Dê um nome à sua cartela de bingo';
 
   @override
-  String get createCardButton => 'Create Bingo Grid';
+  String get createCardButton => 'Criar cartela';
 
   @override
-  String get updateCardButton => 'Update Bingo Grid';
+  String get updateCardButton => 'Atualizar cartela';
 
   @override
   String get newBoardPreMadeSectionTitle => 'Your pre-made items';
@@ -54,10 +54,10 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get defaultCardName => 'Bingo Card';
+  String get defaultCardName => 'Cartela de bingo';
 
   @override
-  String get toggleHint => 'Press long to mark a field as checked';
+  String get toggleHint => 'Prima sem soltar para marcar uma casa';
 
   @override
   String get editingHintBefore => 'Press the lock icon';
@@ -72,10 +72,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get deleteCardConfirm => 'Are you sure you want to delete this card?';
 
   @override
-  String get cancel => 'Cancel';
+  String get cancel => 'Cancelar';
 
   @override
-  String get delete => 'Delete';
+  String get delete => 'Eliminar';
 
   @override
   String get shuffleCardTitle => 'Shuffle Card';
@@ -85,7 +85,7 @@ class AppLocalizationsEn extends AppLocalizations {
       'Are you sure you want to shuffle this card? All fields will be unchecked, after shuffling.';
 
   @override
-  String get shuffle => 'Shuffle';
+  String get shuffle => 'Baralhar';
 
   @override
   String get ratingPromptTitle => 'Do you like Custom Bingo?';
@@ -101,19 +101,19 @@ class AppLocalizationsEn extends AppLocalizations {
   String get ratingPromptYes => 'Yes, I like it';
 
   @override
-  String get boardActionShare => 'Share';
+  String get boardActionShare => 'Partilhar';
 
   @override
-  String get boardActionEditBoard => 'Edit board';
+  String get boardActionEditBoard => 'Editar cartela';
 
   @override
   String get boardActionAddPreMadeItems => 'Add pre-made items';
 
   @override
-  String get cellHint => 'Enter text…';
+  String get cellHint => 'Introduzir texto…';
 
   @override
-  String get edit => 'Edit';
+  String get edit => 'Editar';
 
   @override
   String get markDone => 'Mark Done';
@@ -122,71 +122,71 @@ class AppLocalizationsEn extends AppLocalizations {
   String get markNotDone => 'Mark Not Done';
 
   @override
-  String get newCardMenuItem => 'New bingo board';
+  String get newCardMenuItem => 'Nova cartela de bingo';
 
   @override
-  String get yourCardsHeader => 'Your Boards';
+  String get yourCardsHeader => 'As suas cartelas';
 
   @override
-  String get settingsHeader => 'Settings';
+  String get settingsHeader => 'Definições';
 
   @override
   String get appearanceMenuItem => 'Appearance';
 
   @override
-  String get settingsAppearanceSection => 'Appearance';
+  String get settingsAppearanceSection => 'Aparência';
 
   @override
-  String get settingsPreferencesSection => 'Preferences';
+  String get settingsPreferencesSection => 'Preferências';
 
   @override
-  String get settingsBoardsSection => 'Boards';
+  String get settingsBoardsSection => 'Cartelas';
 
   @override
-  String get settingsHelpSection => 'More';
+  String get settingsHelpSection => 'Mais';
 
   @override
-  String get settingsSupportSection => 'Support';
+  String get settingsSupportSection => 'Apoio';
 
   @override
-  String get themeColorLabel => 'Theme color';
+  String get themeColorLabel => 'Cor do tema';
 
   @override
   String get themeColorSettingsDescription =>
-      'Choose the palette used across the app.';
+      'Escolha a paleta usada em toda a app.';
 
   @override
-  String get languageSettingsTitle => 'Language';
+  String get languageSettingsTitle => 'Idioma';
 
   @override
-  String get languageSettingsSelectorLabel => 'App language';
+  String get languageSettingsSelectorLabel => 'Idioma da app';
 
   @override
   String languageSettingsSystemOption(String language) {
-    return 'System default ($language)';
+    return 'Padrão do sistema ($language)';
   }
 
   @override
   String languageSettingsSystemDescription(String language) {
-    return 'Following your phone language: $language.';
+    return 'Segue o idioma do telefone: $language.';
   }
 
   @override
   String get languageSettingsOverrideDescription =>
-      'Use this language instead of the phone language.';
+      'Usar este idioma em vez do idioma do telefone.';
 
   @override
-  String get darkModeLabel => 'Dark mode';
+  String get darkModeLabel => 'Modo escuro';
 
   @override
-  String get darkModeSettingsDescription => 'Use a darker interface.';
+  String get darkModeSettingsDescription => 'Usar uma interface mais escura.';
 
   @override
-  String get enableConfettiLabel => 'Confetti';
+  String get enableConfettiLabel => 'Confete';
 
   @override
   String get enableConfettiSettingsDescription =>
-      'Show a celebration when you complete a bingo.';
+      'Mostrar uma celebração ao completar um bingo.';
 
   @override
   String get preMadeTilesTitle => 'Pre-made tiles';
@@ -349,23 +349,23 @@ class AppLocalizationsEn extends AppLocalizations {
   String get paywallCouldNotLoad => 'Could not load purchase information.';
 
   @override
-  String get shareTitle => 'Share the bingo card';
+  String get shareTitle => 'Partilhar a cartela de bingo';
 
   @override
   String get shareDialogPrompt => 'How would you like to share?';
 
   @override
-  String get shareImageOptionTitle => 'Share as image';
+  String get shareImageOptionTitle => 'Partilhar como imagem';
 
   @override
   String get shareImageOptionHelper =>
       'Send a picture of your card. Anyone can see it — even without the app.';
 
   @override
-  String get shareImageOptionButton => 'Share image';
+  String get shareImageOptionButton => 'Partilhar imagem';
 
   @override
-  String get shareInviteOptionTitle => 'Invite friends to play';
+  String get shareInviteOptionTitle => 'Convidar amigos para jogar';
 
   @override
   String get shareInviteOptionHelper =>
@@ -379,15 +379,15 @@ class AppLocalizationsEn extends AppLocalizations {
       'When on, your friends will see what you\'ve already crossed off.';
 
   @override
-  String get shareInviteOptionButton => 'Send invite';
+  String get shareInviteOptionButton => 'Enviar convite';
 
   @override
   String shareInviteText(String name, String link) {
-    return 'Play \"$name\" with me! Open it in the app:\n$link';
+    return 'Joga “$name” comigo! Abre na app:\n$link';
   }
 
   @override
-  String get close => 'Close';
+  String get close => 'Fechar';
 
   @override
   String get shareSubject => 'Bingo Card';
@@ -399,10 +399,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get importBody => 'Add it to your cards so you can play along?';
 
   @override
-  String get importConfirm => 'Add to my cards';
+  String get importConfirm => 'Adicionar às minhas cartelas';
 
   @override
-  String get importCancel => 'Not now';
+  String get importCancel => 'Agora não';
 
   @override
   String importCollisionToast(String newName) {
@@ -420,17 +420,17 @@ class AppLocalizationsEn extends AppLocalizations {
   String get toastInfo => 'Info';
 
   @override
-  String get toastSuccess => 'Success';
+  String get toastSuccess => 'Sucesso';
 
   @override
-  String get toastError => 'Error';
+  String get toastError => 'Erro';
 
   @override
-  String get lastChangeNever => 'Last change: Never';
+  String get lastChangeNever => 'Última alteração: nunca';
 
   @override
   String lastChange(String date, String time) {
-    return 'Last change: $date $time';
+    return 'Última alteração: $date $time';
   }
 
   @override

--- a/lib/l10n/arb/app_localizations_pt.dart
+++ b/lib/l10n/arb/app_localizations_pt.dart
@@ -27,30 +27,30 @@ class AppLocalizationsPt extends AppLocalizations {
   String get updateCardButton => 'Atualizar cartela';
 
   @override
-  String get newBoardPreMadeSectionTitle => 'Your pre-made items';
+  String get newBoardPreMadeSectionTitle => 'Seus itens prontos';
 
   @override
-  String get newBoardPreMadeButton => 'Start with pre-made items';
+  String get newBoardPreMadeButton => 'Começar com itens prontos';
 
   @override
-  String get newBoardPreMadeChangeButton => 'Change pre-made items';
+  String get newBoardPreMadeChangeButton => 'Alterar itens prontos';
 
   @override
-  String get newBoardPreMadeClearButton => 'Clear pre-made items';
+  String get newBoardPreMadeClearButton => 'Limpar itens prontos';
 
   @override
   String newBoardPreMadeAppliedCount(int count) {
-    return '$count pre-made entries applied';
+    return '$count entradas prontas aplicadas';
   }
 
   @override
   String newBoardPreMadeFullSummary(int used) {
-    return '$used will be drawn at random for this board.';
+    return '$used serão sorteadas aleatoriamente para este tabuleiro.';
   }
 
   @override
   String newBoardPreMadePartialSummary(int used, int blank) {
-    return '$used cells will be filled. $blank will stay blank.';
+    return '$used células serão preenchidas. $blank ficarão em branco.';
   }
 
   @override
@@ -60,16 +60,17 @@ class AppLocalizationsPt extends AppLocalizations {
   String get toggleHint => 'Prima sem soltar para marcar uma casa';
 
   @override
-  String get editingHintBefore => 'Press the lock icon';
+  String get editingHintBefore => 'Toque no ícone de cadeado';
 
   @override
-  String get editingHintAfter => ' to make the fields not editable anymore.';
+  String get editingHintAfter => ' para impedir a edição dos campos.';
 
   @override
-  String get deleteCardTitle => 'Delete Card';
+  String get deleteCardTitle => 'Excluir cartela';
 
   @override
-  String get deleteCardConfirm => 'Are you sure you want to delete this card?';
+  String get deleteCardConfirm =>
+      'Tem certeza de que deseja excluir esta cartela?';
 
   @override
   String get cancel => 'Cancelar';
@@ -78,27 +79,27 @@ class AppLocalizationsPt extends AppLocalizations {
   String get delete => 'Eliminar';
 
   @override
-  String get shuffleCardTitle => 'Shuffle Card';
+  String get shuffleCardTitle => 'Embaralhar cartela';
 
   @override
   String get shuffleCardConfirm =>
-      'Are you sure you want to shuffle this card? All fields will be unchecked, after shuffling.';
+      'Tem certeza de que deseja embaralhar esta cartela? Todos os campos serão desmarcados depois.';
 
   @override
   String get shuffle => 'Baralhar';
 
   @override
-  String get ratingPromptTitle => 'Do you like Custom Bingo?';
+  String get ratingPromptTitle => 'Você gosta do Custom Bingo?';
 
   @override
   String get ratingPromptBody =>
-      'If so, a quick store review helps others find it.';
+      'Se sim, uma avaliação rápida na loja ajuda outras pessoas a encontrá-lo.';
 
   @override
-  String get ratingPromptNo => 'Not really';
+  String get ratingPromptNo => 'Não muito';
 
   @override
-  String get ratingPromptYes => 'Yes, I like it';
+  String get ratingPromptYes => 'Sim, gosto';
 
   @override
   String get boardActionShare => 'Partilhar';
@@ -107,7 +108,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get boardActionEditBoard => 'Editar cartela';
 
   @override
-  String get boardActionAddPreMadeItems => 'Add pre-made items';
+  String get boardActionAddPreMadeItems => 'Adicionar itens prontos';
 
   @override
   String get cellHint => 'Introduzir texto…';
@@ -116,22 +117,50 @@ class AppLocalizationsPt extends AppLocalizations {
   String get edit => 'Editar';
 
   @override
-  String get markDone => 'Mark Done';
+  String get markDone => 'Marcar como feito';
 
   @override
-  String get markNotDone => 'Mark Not Done';
+  String get markNotDone => 'Marcar como não feito';
 
   @override
   String get newCardMenuItem => 'Nova cartela de bingo';
 
   @override
+  String get allBoardsMenuItem => 'Todas as cartelas';
+
+  @override
   String get yourCardsHeader => 'As suas cartelas';
+
+  @override
+  String get noBoardsYet => 'Ainda não há cartelas';
+
+  @override
+  String get pageNotFoundTitle => 'Página não encontrada';
+
+  @override
+  String get homeButton => 'Início';
+
+  @override
+  String revenueCatUserIdLabel(String userId) {
+    return 'ID de usuário do RevenueCat: $userId';
+  }
+
+  @override
+  String get copyRevenueCatUserIdTooltip =>
+      'Copiar ID de usuário do RevenueCat';
+
+  @override
+  String get revenueCatUserIdCopiedToast =>
+      'ID de usuário do RevenueCat copiado.';
 
   @override
   String get settingsHeader => 'Definições';
 
   @override
-  String get appearanceMenuItem => 'Appearance';
+  String get clearSettingsMenuItem => 'Limpar definições';
+
+  @override
+  String get appearanceMenuItem => 'Aparência';
 
   @override
   String get settingsAppearanceSection => 'Aparência';
@@ -189,177 +218,180 @@ class AppLocalizationsPt extends AppLocalizations {
       'Mostrar uma celebração ao completar um bingo.';
 
   @override
-  String get preMadeTilesTitle => 'Pre-made tiles';
+  String get preMadeTilesTitle => 'Casas prontas';
 
   @override
   String get preMadeTilesSettingsDescription =>
-      'Create reusable tile text for future boards.';
+      'Crie textos reutilizáveis para futuros tabuleiros.';
 
   @override
   String get preMadeTilesDescription =>
-      'Create reusable bingo entries here. When you create a new board, you can add them without typing everything again.';
+      'Crie entradas de bingo reutilizáveis aqui. Ao criar um novo tabuleiro, você pode adicioná-las sem digitar tudo de novo.';
 
   @override
-  String get preMadeTilesSelectMode => 'Select';
+  String get preMadeTilesSelectMode => 'Selecionar';
 
   @override
-  String get preMadeTilesEditMode => 'Edit';
+  String get preMadeTilesEditMode => 'Editar';
 
   @override
-  String get preMadeTileHint => 'Tile text';
+  String get preMadeTileHint => 'Texto da casa';
 
   @override
-  String get preMadeTilesAdd => 'Add tile';
+  String get preMadeTilesAdd => 'Adicionar casa';
 
   @override
-  String get preMadeTilesDelete => 'Delete tile';
+  String get preMadeTilesDelete => 'Excluir casa';
 
   @override
-  String get preMadeTilesSelectAll => 'Un/select all';
+  String get preMadeTilesSelectAll => 'Selecionar/desmarcar tudo';
 
   @override
-  String get preMadeTilesSelectNone => 'Select none';
+  String get preMadeTilesSelectNone => 'Não selecionar nada';
 
   @override
-  String get preMadeTilesApply => 'Apply';
+  String get preMadeTilesApply => 'Aplicar';
 
   @override
-  String get preMadeTilesReplaceItems => 'Replace items';
+  String get preMadeTilesReplaceItems => 'Substituir itens';
 
   @override
-  String get preMadeTilesFillItems => 'Fill items';
+  String get preMadeTilesFillItems => 'Preencher itens';
 
   @override
   String get preMadeTilesBoardActionHelp =>
-      'Replace swaps the board entries with a random draw from your selection. Fill only adds items to empty tiles. On odd boards, the center tile stays in place.';
+      'Substituir troca as entradas do tabuleiro por um sorteio da sua seleção. Preencher só adiciona itens às casas vazias. Em tabuleiros ímpares, a casa central permanece.';
 
   @override
   String preMadeTilesSelectedCount(int selected, int total) {
-    return '$selected / $total selected';
+    return '$selected / $total selecionadas';
   }
 
   @override
-  String get preMadeTilesEmptyTitle => 'No tiles yet';
+  String get preMadeTilesEmptyTitle => 'Ainda não há casas';
 
   @override
   String get preMadeTilesEmptyBody =>
-      'Add a tile to start building a reusable list.';
+      'Adicione uma casa para começar uma lista reutilizável.';
 
   @override
-  String get proposeFeatures => 'Propose Features';
+  String get proposeFeatures => 'Propor recursos';
 
   @override
   String get proposeFeaturesSettingsDescription =>
-      'Vote on ideas and suggest what to build next.';
+      'Vote em ideias e sugira o que criar a seguir.';
 
   @override
-  String get supportMeDirectly => 'Support the developer';
+  String get supportMeDirectly => 'Apoiar o desenvolvedor';
 
   @override
   String get supportMeDirectlySettingsDescription =>
-      'Help fund development and keep the app improving.';
+      'Ajude a financiar o desenvolvimento e manter o app melhorando.';
 
   @override
-  String get supportCarouselProTitle => 'Support Custom Bingo';
+  String get supportCarouselProTitle => 'Apoie o Custom Bingo';
 
   @override
   String get supportCarouselProSubtitle =>
-      'Unlock bonus colors and help keep the app independent.';
+      'Desbloqueie cores extras e ajude a manter o app independente.';
 
   @override
-  String get supportCarouselRateTitle => 'Enjoying the app?';
+  String get supportCarouselRateTitle => 'Está gostando do app?';
 
   @override
   String get supportCarouselRateSubtitle =>
-      'A quick review helps more people find Custom Bingo.';
+      'Uma avaliação rápida ajuda mais pessoas a encontrarem o Custom Bingo.';
 
   @override
-  String get rateTheApp => 'Rate the app';
+  String get rateTheApp => 'Avaliar o app';
 
   @override
-  String get rateTheAppSettingsDescription => 'Open the store rating prompt.';
+  String get rateTheAppSettingsDescription =>
+      'Abrir o pedido de avaliação na loja.';
 
   @override
-  String get contactMe => 'Contact me';
+  String get contactMe => 'Entrar em contato';
 
   @override
   String get contactMeSettingsDescription =>
-      'Send feedback, questions, or bug reports by email.';
+      'Envie comentários, perguntas ou relatos de bugs por email.';
 
   @override
-  String get paywallTitle => 'Support Custom Bingo';
+  String get paywallTitle => 'Apoie o Custom Bingo';
 
   @override
-  String get paywallThankYouTitle => 'Thank you';
+  String get paywallThankYouTitle => 'Obrigado';
 
   @override
-  String get paywallSupportTitle => 'Support Custom Bingo';
+  String get paywallSupportTitle => 'Apoie o Custom Bingo';
 
   @override
   String get paywallSupportBody =>
-      'This purchase supports me, the developer, directly. You get my gratitude and a few small bonus things for your boards.';
+      'Esta compra me apoia diretamente, o desenvolvedor. Você recebe minha gratidão e alguns pequenos extras para seus tabuleiros.';
 
   @override
-  String get paywallBonusGratitude => 'My gratitude, sincerely.';
+  String get paywallBonusGratitude => 'Minha gratidão, de verdade.';
 
   @override
-  String get paywallBonusColors => 'A few extra board colors.';
+  String get paywallBonusColors => 'Algumas cores extras para tabuleiros.';
 
   @override
-  String get paywallBonusExtras => 'Small supporter extras over time.';
+  String get paywallBonusExtras =>
+      'Pequenos extras de apoiador ao longo do tempo.';
 
   @override
   String get paywallFreeForever =>
-      'No one ever needs to pay for this app. Custom Bingo stays usable for everyone.';
+      'Ninguém precisa pagar por este app. O Custom Bingo continua utilizável para todos.';
 
   @override
-  String get paywallLoadingPrice => 'Loading price';
+  String get paywallLoadingPrice => 'Carregando preço';
 
   @override
-  String get paywallUnavailable => 'Unavailable';
+  String get paywallUnavailable => 'Indisponível';
 
   @override
-  String get paywallSupportOnce => 'Support once';
+  String get paywallSupportOnce => 'Apoiar uma vez';
 
   @override
-  String get paywallRestorePurchase => 'Restore purchase';
+  String get paywallRestorePurchase => 'Restaurar compra';
 
   @override
-  String get paywallProActiveToast => 'Custom Bingo Pro is active.';
+  String get paywallProActiveToast => 'Custom Bingo Pro está ativo.';
 
   @override
   String get paywallPurchaseInactiveToast =>
-      'Purchase finished, but Pro is not active.';
+      'A compra terminou, mas o Pro não está ativo.';
 
   @override
-  String get paywallProRestoredToast => 'Custom Bingo Pro restored.';
+  String get paywallProRestoredToast => 'Custom Bingo Pro restaurado.';
 
   @override
-  String get paywallNoPurchaseFoundToast => 'No Pro purchase found.';
+  String get paywallNoPurchaseFoundToast => 'Nenhuma compra Pro encontrada.';
 
   @override
   String get paywallPurchasesUnavailable =>
-      'Purchases are unavailable right now.';
+      'As compras estão indisponíveis no momento.';
 
   @override
   String get paywallPlatformUnavailable =>
-      'Purchases are unavailable on this platform.';
+      'As compras não estão disponíveis nesta plataforma.';
 
   @override
-  String get paywallCouldNotLoad => 'Could not load purchase information.';
+  String get paywallCouldNotLoad =>
+      'Não foi possível carregar as informações de compra.';
 
   @override
   String get shareTitle => 'Partilhar a cartela de bingo';
 
   @override
-  String get shareDialogPrompt => 'How would you like to share?';
+  String get shareDialogPrompt => 'Como você gostaria de compartilhar?';
 
   @override
   String get shareImageOptionTitle => 'Partilhar como imagem';
 
   @override
   String get shareImageOptionHelper =>
-      'Send a picture of your card. Anyone can see it — even without the app.';
+      'Envie uma imagem da sua cartela. Qualquer pessoa pode ver, mesmo sem o app.';
 
   @override
   String get shareImageOptionButton => 'Partilhar imagem';
@@ -369,14 +401,14 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get shareInviteOptionHelper =>
-      'Send this link to your friends who also have this app installed. They get the same card and you can play together.';
+      'Envie este link para amigos que também têm este app instalado. Eles recebem a mesma cartela e vocês podem jogar juntos.';
 
   @override
-  String get shareInviteIncludeMarks => 'Include my checkmarks';
+  String get shareInviteIncludeMarks => 'Incluir minhas marcações';
 
   @override
   String get shareInviteIncludeMarksHelper =>
-      'When on, your friends will see what you\'ve already crossed off.';
+      'Quando ativado, seus amigos verão o que você já marcou.';
 
   @override
   String get shareInviteOptionButton => 'Enviar convite';
@@ -390,13 +422,14 @@ class AppLocalizationsPt extends AppLocalizations {
   String get close => 'Fechar';
 
   @override
-  String get shareSubject => 'Bingo Card';
+  String get shareSubject => 'Cartela de bingo';
 
   @override
-  String get importTitle => 'A friend shared a bingo card with you';
+  String get importTitle =>
+      'Um amigo compartilhou uma cartela de bingo com você';
 
   @override
-  String get importBody => 'Add it to your cards so you can play along?';
+  String get importBody => 'Adicionar às suas cartelas para jogar junto?';
 
   @override
   String get importConfirm => 'Adicionar às minhas cartelas';
@@ -406,18 +439,19 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String importCollisionToast(String newName) {
-    return 'You already had a card with this name, so I added it as \"$newName\".';
+    return 'Você já tinha uma cartela com este nome, então eu a adicionei como \"$newName\".';
   }
 
   @override
   String get importBadLinkToast =>
-      'Sorry, this invite couldn\'t be opened. Ask your friend to send it again.';
+      'Desculpe, este convite não pôde ser aberto. Peça ao seu amigo para enviá-lo novamente.';
 
   @override
-  String get importOutdatedAppToast => 'Update the app to open this invite.';
+  String get importOutdatedAppToast =>
+      'Atualize o app para abrir este convite.';
 
   @override
-  String get toastInfo => 'Info';
+  String get toastInfo => 'Informação';
 
   @override
   String get toastSuccess => 'Sucesso';
@@ -435,42 +469,42 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get screenshotCaptionPlaying =>
-      'Just a simple app to create bingo board.\n\nNo signup, no ads, fully free to use.';
+      'Um app simples para criar tabuleiros de bingo.\\n\\nSem cadastro, sem anúncios e totalmente grátis.';
 
   @override
   String get screenshotCaptionCreate =>
-      'Literally just 2 screens to create a bingo grid.';
+      'Literalmente só duas telas para criar uma grade de bingo.';
 
   @override
-  String get screenshotCaptionLocked => 'That\'s it.';
+  String get screenshotCaptionLocked => 'É isso.';
 
   @override
-  String get screenshotBoardName => 'David\'s Wedding';
+  String get screenshotBoardName => 'Casamento do David';
 
   @override
-  String get screenshotTilePhoneDuringVows => 'Phone during vows';
+  String get screenshotTilePhoneDuringVows => 'Celular durante os votos';
 
   @override
-  String get screenshotTileChampagneSpilled => 'Champagne spilled';
+  String get screenshotTileChampagneSpilled => 'Champanhe derramado';
 
   @override
-  String get screenshotTileSpeechTears => 'Speech tears';
+  String get screenshotTileSpeechTears => 'Lágrimas no discurso';
 
   @override
-  String get screenshotTileDramaticEntrance => 'Dramatic entrance';
+  String get screenshotTileDramaticEntrance => 'Entrada dramática';
 
   @override
-  String get screenshotTileKidsDanceFloor => 'Kids take the dance floor';
+  String get screenshotTileKidsDanceFloor => 'Crianças na pista';
 
   @override
-  String get screenshotTileGuestToast => 'Guest gives a toast';
+  String get screenshotTileGuestToast => 'Convidado faz um brinde';
 
   @override
-  String get screenshotTileCrowdClapsEarly => 'Crowd claps early';
+  String get screenshotTileCrowdClapsEarly => 'Aplausos cedo demais';
 
   @override
-  String get screenshotTileDjClassic => 'DJ plays a classic';
+  String get screenshotTileDjClassic => 'DJ toca um clássico';
 
   @override
-  String get screenshotTileGroupPhotoChaos => 'Group photo chaos';
+  String get screenshotTileGroupPhotoChaos => 'Caos na foto de grupo';
 }

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -27,30 +27,30 @@ class AppLocalizationsZh extends AppLocalizations {
   String get updateCardButton => '更新宾果表';
 
   @override
-  String get newBoardPreMadeSectionTitle => 'Your pre-made items';
+  String get newBoardPreMadeSectionTitle => '你的预制项目';
 
   @override
-  String get newBoardPreMadeButton => 'Start with pre-made items';
+  String get newBoardPreMadeButton => '从预制项目开始';
 
   @override
-  String get newBoardPreMadeChangeButton => 'Change pre-made items';
+  String get newBoardPreMadeChangeButton => '更改预制项目';
 
   @override
-  String get newBoardPreMadeClearButton => 'Clear pre-made items';
+  String get newBoardPreMadeClearButton => '清除预制项目';
 
   @override
   String newBoardPreMadeAppliedCount(int count) {
-    return '$count pre-made entries applied';
+    return '已应用 $count 个预制条目';
   }
 
   @override
   String newBoardPreMadeFullSummary(int used) {
-    return '$used will be drawn at random for this board.';
+    return '将为此棋盘随机抽取 $used 个。';
   }
 
   @override
   String newBoardPreMadePartialSummary(int used, int blank) {
-    return '$used cells will be filled. $blank will stay blank.';
+    return '将填充 $used 个格子，$blank 个保持空白。';
   }
 
   @override
@@ -60,16 +60,16 @@ class AppLocalizationsZh extends AppLocalizations {
   String get toggleHint => '长按可勾选格子';
 
   @override
-  String get editingHintBefore => 'Press the lock icon';
+  String get editingHintBefore => '按锁定图标';
 
   @override
-  String get editingHintAfter => ' to make the fields not editable anymore.';
+  String get editingHintAfter => '，让格子不再可编辑。';
 
   @override
-  String get deleteCardTitle => 'Delete Card';
+  String get deleteCardTitle => '删除卡片';
 
   @override
-  String get deleteCardConfirm => 'Are you sure you want to delete this card?';
+  String get deleteCardConfirm => '确定要删除这张卡片吗？';
 
   @override
   String get cancel => '取消';
@@ -78,27 +78,25 @@ class AppLocalizationsZh extends AppLocalizations {
   String get delete => '删除';
 
   @override
-  String get shuffleCardTitle => 'Shuffle Card';
+  String get shuffleCardTitle => '打乱卡片';
 
   @override
-  String get shuffleCardConfirm =>
-      'Are you sure you want to shuffle this card? All fields will be unchecked, after shuffling.';
+  String get shuffleCardConfirm => '确定要打乱这张卡片吗？打乱后所有格子都会取消勾选。';
 
   @override
   String get shuffle => '随机排列';
 
   @override
-  String get ratingPromptTitle => 'Do you like Custom Bingo?';
+  String get ratingPromptTitle => '你喜欢 Custom Bingo 吗？';
 
   @override
-  String get ratingPromptBody =>
-      'If so, a quick store review helps others find it.';
+  String get ratingPromptBody => '如果喜欢，商店里的简短评价能帮助更多人发现它。';
 
   @override
-  String get ratingPromptNo => 'Not really';
+  String get ratingPromptNo => '不太喜欢';
 
   @override
-  String get ratingPromptYes => 'Yes, I like it';
+  String get ratingPromptYes => '是的，我喜欢';
 
   @override
   String get boardActionShare => '分享';
@@ -107,7 +105,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get boardActionEditBoard => '编辑棋盘';
 
   @override
-  String get boardActionAddPreMadeItems => 'Add pre-made items';
+  String get boardActionAddPreMadeItems => '添加预制项目';
 
   @override
   String get cellHint => '输入文字…';
@@ -116,22 +114,48 @@ class AppLocalizationsZh extends AppLocalizations {
   String get edit => '编辑';
 
   @override
-  String get markDone => 'Mark Done';
+  String get markDone => '标记完成';
 
   @override
-  String get markNotDone => 'Mark Not Done';
+  String get markNotDone => '标记未完成';
 
   @override
   String get newCardMenuItem => '新建宾果棋盘';
 
   @override
+  String get allBoardsMenuItem => '所有棋盘';
+
+  @override
   String get yourCardsHeader => '你的棋盘';
+
+  @override
+  String get noBoardsYet => '还没有棋盘';
+
+  @override
+  String get pageNotFoundTitle => '找不到页面';
+
+  @override
+  String get homeButton => '首页';
+
+  @override
+  String revenueCatUserIdLabel(String userId) {
+    return 'RevenueCat 用户 ID：$userId';
+  }
+
+  @override
+  String get copyRevenueCatUserIdTooltip => '复制 RevenueCat 用户 ID';
+
+  @override
+  String get revenueCatUserIdCopiedToast => '已复制 RevenueCat 用户 ID。';
 
   @override
   String get settingsHeader => '设置';
 
   @override
-  String get appearanceMenuItem => 'Appearance';
+  String get clearSettingsMenuItem => '清除设置';
+
+  @override
+  String get appearanceMenuItem => '外观';
 
   @override
   String get settingsAppearanceSection => '外观';
@@ -186,177 +210,163 @@ class AppLocalizationsZh extends AppLocalizations {
   String get enableConfettiSettingsDescription => '完成宾果时显示庆祝效果。';
 
   @override
-  String get preMadeTilesTitle => 'Pre-made tiles';
+  String get preMadeTilesTitle => '预制格子';
 
   @override
-  String get preMadeTilesSettingsDescription =>
-      'Create reusable tile text for future boards.';
+  String get preMadeTilesSettingsDescription => '为未来的棋盘创建可复用的格子文字。';
 
   @override
-  String get preMadeTilesDescription =>
-      'Create reusable bingo entries here. When you create a new board, you can add them without typing everything again.';
+  String get preMadeTilesDescription => '在这里创建可复用的宾果条目。创建新棋盘时，无需重新输入即可添加。';
 
   @override
-  String get preMadeTilesSelectMode => 'Select';
+  String get preMadeTilesSelectMode => '选择';
 
   @override
-  String get preMadeTilesEditMode => 'Edit';
+  String get preMadeTilesEditMode => '编辑';
 
   @override
-  String get preMadeTileHint => 'Tile text';
+  String get preMadeTileHint => '格子文字';
 
   @override
-  String get preMadeTilesAdd => 'Add tile';
+  String get preMadeTilesAdd => '添加格子';
 
   @override
-  String get preMadeTilesDelete => 'Delete tile';
+  String get preMadeTilesDelete => '删除格子';
 
   @override
-  String get preMadeTilesSelectAll => 'Un/select all';
+  String get preMadeTilesSelectAll => '全选/取消全选';
 
   @override
-  String get preMadeTilesSelectNone => 'Select none';
+  String get preMadeTilesSelectNone => '全部不选';
 
   @override
-  String get preMadeTilesApply => 'Apply';
+  String get preMadeTilesApply => '应用';
 
   @override
-  String get preMadeTilesReplaceItems => 'Replace items';
+  String get preMadeTilesReplaceItems => '替换项目';
 
   @override
-  String get preMadeTilesFillItems => 'Fill items';
+  String get preMadeTilesFillItems => '填充项目';
 
   @override
   String get preMadeTilesBoardActionHelp =>
-      'Replace swaps the board entries with a random draw from your selection. Fill only adds items to empty tiles. On odd boards, the center tile stays in place.';
+      '替换会从你的选择中随机抽取并替换棋盘条目。填充只会把项目添加到空格子。奇数棋盘中，中心格保持不变。';
 
   @override
   String preMadeTilesSelectedCount(int selected, int total) {
-    return '$selected / $total selected';
+    return '已选择 $selected / $total';
   }
 
   @override
-  String get preMadeTilesEmptyTitle => 'No tiles yet';
+  String get preMadeTilesEmptyTitle => '还没有格子';
 
   @override
-  String get preMadeTilesEmptyBody =>
-      'Add a tile to start building a reusable list.';
+  String get preMadeTilesEmptyBody => '添加一个格子，开始建立可复用列表。';
 
   @override
-  String get proposeFeatures => 'Propose Features';
+  String get proposeFeatures => '提议功能';
 
   @override
-  String get proposeFeaturesSettingsDescription =>
-      'Vote on ideas and suggest what to build next.';
+  String get proposeFeaturesSettingsDescription => '为想法投票，并建议下一步要构建什么。';
 
   @override
-  String get supportMeDirectly => 'Support the developer';
+  String get supportMeDirectly => '支持开发者';
 
   @override
-  String get supportMeDirectlySettingsDescription =>
-      'Help fund development and keep the app improving.';
+  String get supportMeDirectlySettingsDescription => '帮助资助开发，让应用持续改进。';
 
   @override
-  String get supportCarouselProTitle => 'Support Custom Bingo';
+  String get supportCarouselProTitle => '支持 Custom Bingo';
 
   @override
-  String get supportCarouselProSubtitle =>
-      'Unlock bonus colors and help keep the app independent.';
+  String get supportCarouselProSubtitle => '解锁额外颜色，并帮助应用保持独立。';
 
   @override
-  String get supportCarouselRateTitle => 'Enjoying the app?';
+  String get supportCarouselRateTitle => '喜欢这个应用吗？';
 
   @override
-  String get supportCarouselRateSubtitle =>
-      'A quick review helps more people find Custom Bingo.';
+  String get supportCarouselRateSubtitle => '简短评价能帮助更多人发现 Custom Bingo。';
 
   @override
-  String get rateTheApp => 'Rate the app';
+  String get rateTheApp => '评价应用';
 
   @override
-  String get rateTheAppSettingsDescription => 'Open the store rating prompt.';
+  String get rateTheAppSettingsDescription => '打开商店评分提示。';
 
   @override
-  String get contactMe => 'Contact me';
+  String get contactMe => '联系我';
 
   @override
-  String get contactMeSettingsDescription =>
-      'Send feedback, questions, or bug reports by email.';
+  String get contactMeSettingsDescription => '通过电子邮件发送反馈、问题或错误报告。';
 
   @override
-  String get paywallTitle => 'Support Custom Bingo';
+  String get paywallTitle => '支持 Custom Bingo';
 
   @override
-  String get paywallThankYouTitle => 'Thank you';
+  String get paywallThankYouTitle => '谢谢';
 
   @override
-  String get paywallSupportTitle => 'Support Custom Bingo';
+  String get paywallSupportTitle => '支持 Custom Bingo';
 
   @override
-  String get paywallSupportBody =>
-      'This purchase supports me, the developer, directly. You get my gratitude and a few small bonus things for your boards.';
+  String get paywallSupportBody => '这笔购买会直接支持我，也就是开发者。你会得到我的感谢，以及一些用于棋盘的小奖励。';
 
   @override
-  String get paywallBonusGratitude => 'My gratitude, sincerely.';
+  String get paywallBonusGratitude => '真诚感谢。';
 
   @override
-  String get paywallBonusColors => 'A few extra board colors.';
+  String get paywallBonusColors => '一些额外棋盘颜色。';
 
   @override
-  String get paywallBonusExtras => 'Small supporter extras over time.';
+  String get paywallBonusExtras => '未来的小支持者奖励。';
 
   @override
-  String get paywallFreeForever =>
-      'No one ever needs to pay for this app. Custom Bingo stays usable for everyone.';
+  String get paywallFreeForever => '没有人必须为这个应用付费。Custom Bingo 会继续对所有人可用。';
 
   @override
-  String get paywallLoadingPrice => 'Loading price';
+  String get paywallLoadingPrice => '正在加载价格';
 
   @override
-  String get paywallUnavailable => 'Unavailable';
+  String get paywallUnavailable => '不可用';
 
   @override
-  String get paywallSupportOnce => 'Support once';
+  String get paywallSupportOnce => '支持一次';
 
   @override
-  String get paywallRestorePurchase => 'Restore purchase';
+  String get paywallRestorePurchase => '恢复购买';
 
   @override
-  String get paywallProActiveToast => 'Custom Bingo Pro is active.';
+  String get paywallProActiveToast => 'Custom Bingo Pro 已启用。';
 
   @override
-  String get paywallPurchaseInactiveToast =>
-      'Purchase finished, but Pro is not active.';
+  String get paywallPurchaseInactiveToast => '购买已完成，但 Pro 未启用。';
 
   @override
-  String get paywallProRestoredToast => 'Custom Bingo Pro restored.';
+  String get paywallProRestoredToast => 'Custom Bingo Pro 已恢复。';
 
   @override
-  String get paywallNoPurchaseFoundToast => 'No Pro purchase found.';
+  String get paywallNoPurchaseFoundToast => '未找到 Pro 购买记录。';
 
   @override
-  String get paywallPurchasesUnavailable =>
-      'Purchases are unavailable right now.';
+  String get paywallPurchasesUnavailable => '目前无法购买。';
 
   @override
-  String get paywallPlatformUnavailable =>
-      'Purchases are unavailable on this platform.';
+  String get paywallPlatformUnavailable => '此平台不支持购买。';
 
   @override
-  String get paywallCouldNotLoad => 'Could not load purchase information.';
+  String get paywallCouldNotLoad => '无法加载购买信息。';
 
   @override
   String get shareTitle => '分享宾果卡';
 
   @override
-  String get shareDialogPrompt => 'How would you like to share?';
+  String get shareDialogPrompt => '你想如何分享？';
 
   @override
   String get shareImageOptionTitle => '以图片分享';
 
   @override
-  String get shareImageOptionHelper =>
-      'Send a picture of your card. Anyone can see it — even without the app.';
+  String get shareImageOptionHelper => '发送你的卡片图片。即使没有应用，任何人也能查看。';
 
   @override
   String get shareImageOptionButton => '分享图片';
@@ -366,14 +376,13 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get shareInviteOptionHelper =>
-      'Send this link to your friends who also have this app installed. They get the same card and you can play together.';
+      '把这个链接发送给同样安装了此应用的朋友。他们会得到同一张卡片，你们可以一起玩。';
 
   @override
-  String get shareInviteIncludeMarks => 'Include my checkmarks';
+  String get shareInviteIncludeMarks => '包含我的勾选';
 
   @override
-  String get shareInviteIncludeMarksHelper =>
-      'When on, your friends will see what you\'ve already crossed off.';
+  String get shareInviteIncludeMarksHelper => '开启后，朋友会看到你已经划掉的内容。';
 
   @override
   String get shareInviteOptionButton => '发送邀请';
@@ -387,13 +396,13 @@ class AppLocalizationsZh extends AppLocalizations {
   String get close => '关闭';
 
   @override
-  String get shareSubject => 'Bingo Card';
+  String get shareSubject => '宾果卡片';
 
   @override
-  String get importTitle => 'A friend shared a bingo card with you';
+  String get importTitle => '朋友与你分享了一张宾果卡片';
 
   @override
-  String get importBody => 'Add it to your cards so you can play along?';
+  String get importBody => '要添加到你的卡片中一起玩吗？';
 
   @override
   String get importConfirm => '添加到我的卡片';
@@ -403,15 +412,14 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String importCollisionToast(String newName) {
-    return 'You already had a card with this name, so I added it as \"$newName\".';
+    return '你已经有同名卡片，所以我将它添加为“$newName”。';
   }
 
   @override
-  String get importBadLinkToast =>
-      'Sorry, this invite couldn\'t be opened. Ask your friend to send it again.';
+  String get importBadLinkToast => '抱歉，无法打开此邀请。请让朋友重新发送。';
 
   @override
-  String get importOutdatedAppToast => 'Update the app to open this invite.';
+  String get importOutdatedAppToast => '请更新应用以打开此邀请。';
 
   @override
   String get toastInfo => '信息';
@@ -431,43 +439,41 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String get screenshotCaptionPlaying =>
-      'Just a simple app to create bingo board.\n\nNo signup, no ads, fully free to use.';
+  String get screenshotCaptionPlaying => '一个用于创建宾果棋盘的简单应用。\\n\\n无需注册、无广告、完全免费。';
 
   @override
-  String get screenshotCaptionCreate =>
-      'Literally just 2 screens to create a bingo grid.';
+  String get screenshotCaptionCreate => '只需两个屏幕即可创建宾果网格。';
 
   @override
-  String get screenshotCaptionLocked => 'That\'s it.';
+  String get screenshotCaptionLocked => '就这样。';
 
   @override
-  String get screenshotBoardName => 'David\'s Wedding';
+  String get screenshotBoardName => 'David 的婚礼';
 
   @override
-  String get screenshotTilePhoneDuringVows => 'Phone during vows';
+  String get screenshotTilePhoneDuringVows => '宣誓时手机响';
 
   @override
-  String get screenshotTileChampagneSpilled => 'Champagne spilled';
+  String get screenshotTileChampagneSpilled => '香槟洒了';
 
   @override
-  String get screenshotTileSpeechTears => 'Speech tears';
+  String get screenshotTileSpeechTears => '致辞落泪';
 
   @override
-  String get screenshotTileDramaticEntrance => 'Dramatic entrance';
+  String get screenshotTileDramaticEntrance => '戏剧性入场';
 
   @override
-  String get screenshotTileKidsDanceFloor => 'Kids take the dance floor';
+  String get screenshotTileKidsDanceFloor => '孩子们冲上舞池';
 
   @override
-  String get screenshotTileGuestToast => 'Guest gives a toast';
+  String get screenshotTileGuestToast => '宾客敬酒';
 
   @override
-  String get screenshotTileCrowdClapsEarly => 'Crowd claps early';
+  String get screenshotTileCrowdClapsEarly => '人群提前鼓掌';
 
   @override
-  String get screenshotTileDjClassic => 'DJ plays a classic';
+  String get screenshotTileDjClassic => 'DJ 播放经典曲目';
 
   @override
-  String get screenshotTileGroupPhotoChaos => 'Group photo chaos';
+  String get screenshotTileGroupPhotoChaos => '合影现场混乱';
 }

--- a/lib/l10n/arb/app_localizations_zh.dart
+++ b/lib/l10n/arb/app_localizations_zh.dart
@@ -4,27 +4,27 @@ import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
 
-/// The translations for English (`en`).
-class AppLocalizationsEn extends AppLocalizations {
-  AppLocalizationsEn([String locale = 'en']) : super(locale);
+/// The translations for Chinese (`zh`).
+class AppLocalizationsZh extends AppLocalizations {
+  AppLocalizationsZh([String locale = 'zh']) : super(locale);
 
   @override
-  String get newCardTitle => 'Create New Bingo Grid';
+  String get newCardTitle => '创建新的宾果表';
 
   @override
-  String get editCardTitle => 'Edit Bingo Grid';
+  String get editCardTitle => '编辑宾果表';
 
   @override
-  String get cardNameLabel => 'Bingo Grid Name *';
+  String get cardNameLabel => '宾果表名称 *';
 
   @override
-  String get cardNameHint => 'Enter a name for your bingo grid';
+  String get cardNameHint => '输入宾果表名称';
 
   @override
-  String get createCardButton => 'Create Bingo Grid';
+  String get createCardButton => '创建宾果表';
 
   @override
-  String get updateCardButton => 'Update Bingo Grid';
+  String get updateCardButton => '更新宾果表';
 
   @override
   String get newBoardPreMadeSectionTitle => 'Your pre-made items';
@@ -54,10 +54,10 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get defaultCardName => 'Bingo Card';
+  String get defaultCardName => '宾果卡';
 
   @override
-  String get toggleHint => 'Press long to mark a field as checked';
+  String get toggleHint => '长按可勾选格子';
 
   @override
   String get editingHintBefore => 'Press the lock icon';
@@ -72,10 +72,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get deleteCardConfirm => 'Are you sure you want to delete this card?';
 
   @override
-  String get cancel => 'Cancel';
+  String get cancel => '取消';
 
   @override
-  String get delete => 'Delete';
+  String get delete => '删除';
 
   @override
   String get shuffleCardTitle => 'Shuffle Card';
@@ -85,7 +85,7 @@ class AppLocalizationsEn extends AppLocalizations {
       'Are you sure you want to shuffle this card? All fields will be unchecked, after shuffling.';
 
   @override
-  String get shuffle => 'Shuffle';
+  String get shuffle => '随机排列';
 
   @override
   String get ratingPromptTitle => 'Do you like Custom Bingo?';
@@ -101,19 +101,19 @@ class AppLocalizationsEn extends AppLocalizations {
   String get ratingPromptYes => 'Yes, I like it';
 
   @override
-  String get boardActionShare => 'Share';
+  String get boardActionShare => '分享';
 
   @override
-  String get boardActionEditBoard => 'Edit board';
+  String get boardActionEditBoard => '编辑棋盘';
 
   @override
   String get boardActionAddPreMadeItems => 'Add pre-made items';
 
   @override
-  String get cellHint => 'Enter text…';
+  String get cellHint => '输入文字…';
 
   @override
-  String get edit => 'Edit';
+  String get edit => '编辑';
 
   @override
   String get markDone => 'Mark Done';
@@ -122,71 +122,68 @@ class AppLocalizationsEn extends AppLocalizations {
   String get markNotDone => 'Mark Not Done';
 
   @override
-  String get newCardMenuItem => 'New bingo board';
+  String get newCardMenuItem => '新建宾果棋盘';
 
   @override
-  String get yourCardsHeader => 'Your Boards';
+  String get yourCardsHeader => '你的棋盘';
 
   @override
-  String get settingsHeader => 'Settings';
+  String get settingsHeader => '设置';
 
   @override
   String get appearanceMenuItem => 'Appearance';
 
   @override
-  String get settingsAppearanceSection => 'Appearance';
+  String get settingsAppearanceSection => '外观';
 
   @override
-  String get settingsPreferencesSection => 'Preferences';
+  String get settingsPreferencesSection => '偏好设置';
 
   @override
-  String get settingsBoardsSection => 'Boards';
+  String get settingsBoardsSection => '棋盘';
 
   @override
-  String get settingsHelpSection => 'More';
+  String get settingsHelpSection => '更多';
 
   @override
-  String get settingsSupportSection => 'Support';
+  String get settingsSupportSection => '支持';
 
   @override
-  String get themeColorLabel => 'Theme color';
+  String get themeColorLabel => '主题颜色';
 
   @override
-  String get themeColorSettingsDescription =>
-      'Choose the palette used across the app.';
+  String get themeColorSettingsDescription => '选择整个应用使用的配色。';
 
   @override
-  String get languageSettingsTitle => 'Language';
+  String get languageSettingsTitle => '语言';
 
   @override
-  String get languageSettingsSelectorLabel => 'App language';
+  String get languageSettingsSelectorLabel => '应用语言';
 
   @override
   String languageSettingsSystemOption(String language) {
-    return 'System default ($language)';
+    return '系统默认（$language）';
   }
 
   @override
   String languageSettingsSystemDescription(String language) {
-    return 'Following your phone language: $language.';
+    return '跟随手机语言：$language。';
   }
 
   @override
-  String get languageSettingsOverrideDescription =>
-      'Use this language instead of the phone language.';
+  String get languageSettingsOverrideDescription => '使用此语言，而不是手机语言。';
 
   @override
-  String get darkModeLabel => 'Dark mode';
+  String get darkModeLabel => '深色模式';
 
   @override
-  String get darkModeSettingsDescription => 'Use a darker interface.';
+  String get darkModeSettingsDescription => '使用更深色的界面。';
 
   @override
-  String get enableConfettiLabel => 'Confetti';
+  String get enableConfettiLabel => '彩纸';
 
   @override
-  String get enableConfettiSettingsDescription =>
-      'Show a celebration when you complete a bingo.';
+  String get enableConfettiSettingsDescription => '完成宾果时显示庆祝效果。';
 
   @override
   String get preMadeTilesTitle => 'Pre-made tiles';
@@ -349,23 +346,23 @@ class AppLocalizationsEn extends AppLocalizations {
   String get paywallCouldNotLoad => 'Could not load purchase information.';
 
   @override
-  String get shareTitle => 'Share the bingo card';
+  String get shareTitle => '分享宾果卡';
 
   @override
   String get shareDialogPrompt => 'How would you like to share?';
 
   @override
-  String get shareImageOptionTitle => 'Share as image';
+  String get shareImageOptionTitle => '以图片分享';
 
   @override
   String get shareImageOptionHelper =>
       'Send a picture of your card. Anyone can see it — even without the app.';
 
   @override
-  String get shareImageOptionButton => 'Share image';
+  String get shareImageOptionButton => '分享图片';
 
   @override
-  String get shareInviteOptionTitle => 'Invite friends to play';
+  String get shareInviteOptionTitle => '邀请朋友一起玩';
 
   @override
   String get shareInviteOptionHelper =>
@@ -379,15 +376,15 @@ class AppLocalizationsEn extends AppLocalizations {
       'When on, your friends will see what you\'ve already crossed off.';
 
   @override
-  String get shareInviteOptionButton => 'Send invite';
+  String get shareInviteOptionButton => '发送邀请';
 
   @override
   String shareInviteText(String name, String link) {
-    return 'Play \"$name\" with me! Open it in the app:\n$link';
+    return '和我一起玩“$name”！在应用中打开：\n$link';
   }
 
   @override
-  String get close => 'Close';
+  String get close => '关闭';
 
   @override
   String get shareSubject => 'Bingo Card';
@@ -399,10 +396,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get importBody => 'Add it to your cards so you can play along?';
 
   @override
-  String get importConfirm => 'Add to my cards';
+  String get importConfirm => '添加到我的卡片';
 
   @override
-  String get importCancel => 'Not now';
+  String get importCancel => '暂不';
 
   @override
   String importCollisionToast(String newName) {
@@ -417,20 +414,20 @@ class AppLocalizationsEn extends AppLocalizations {
   String get importOutdatedAppToast => 'Update the app to open this invite.';
 
   @override
-  String get toastInfo => 'Info';
+  String get toastInfo => '信息';
 
   @override
-  String get toastSuccess => 'Success';
+  String get toastSuccess => '成功';
 
   @override
-  String get toastError => 'Error';
+  String get toastError => '错误';
 
   @override
-  String get lastChangeNever => 'Last change: Never';
+  String get lastChangeNever => '上次更改：从未';
 
   @override
   String lastChange(String date, String time) {
-    return 'Last change: $date $time';
+    return '上次更改：$date $time';
   }
 
   @override

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -24,23 +24,23 @@
     "@updateCardButton": {
         "description": "Confirm button on the edit-card screen"
     },
-    "newBoardPreMadeSectionTitle": "Your pre-made items",
+    "newBoardPreMadeSectionTitle": "Seus itens prontos",
     "@newBoardPreMadeSectionTitle": {
         "description": "Expandable section title for pre-made items on the new-board screen"
     },
-    "newBoardPreMadeButton": "Start with pre-made items",
+    "newBoardPreMadeButton": "Começar com itens prontos",
     "@newBoardPreMadeButton": {
         "description": "Button that opens pre-made item selection from the new-board screen"
     },
-    "newBoardPreMadeChangeButton": "Change pre-made items",
+    "newBoardPreMadeChangeButton": "Alterar itens prontos",
     "@newBoardPreMadeChangeButton": {
         "description": "Button that reopens pre-made item selection after items have been applied"
     },
-    "newBoardPreMadeClearButton": "Clear pre-made items",
+    "newBoardPreMadeClearButton": "Limpar itens prontos",
     "@newBoardPreMadeClearButton": {
         "description": "Button that clears applied pre-made entries from the new-board form"
     },
-    "newBoardPreMadeAppliedCount": "{count} pre-made entries applied",
+    "newBoardPreMadeAppliedCount": "{count} entradas prontas aplicadas",
     "@newBoardPreMadeAppliedCount": {
         "description": "Summary of how many pre-made entries are applied to the new-board form",
         "placeholders": {
@@ -50,7 +50,7 @@
             }
         }
     },
-    "newBoardPreMadeFullSummary": "{used} will be drawn at random for this board.",
+    "newBoardPreMadeFullSummary": "{used} serão sorteadas aleatoriamente para este tabuleiro.",
     "@newBoardPreMadeFullSummary": {
         "description": "Summary when applied pre-made entries can fill the new board",
         "placeholders": {
@@ -60,7 +60,7 @@
             }
         }
     },
-    "newBoardPreMadePartialSummary": "{used} cells will be filled. {blank} will stay blank.",
+    "newBoardPreMadePartialSummary": "{used} células serão preenchidas. {blank} ficarão em branco.",
     "@newBoardPreMadePartialSummary": {
         "description": "Summary when applied pre-made entries are fewer than the board cells",
         "placeholders": {
@@ -82,19 +82,19 @@
     "@toggleHint": {
         "description": "Hint banner above the bingo grid"
     },
-    "editingHintBefore": "Press the lock icon",
+    "editingHintBefore": "Toque no ícone de cadeado",
     "@editingHintBefore": {
         "description": "First half of the hint that explains the lock toggle. The lock icon is rendered between the two halves."
     },
-    "editingHintAfter": " to make the fields not editable anymore.",
+    "editingHintAfter": " para impedir a edição dos campos.",
     "@editingHintAfter": {
         "description": "Second half of the lock-toggle hint, rendered after the lock icon."
     },
-    "deleteCardTitle": "Delete Card",
+    "deleteCardTitle": "Excluir cartela",
     "@deleteCardTitle": {
         "description": "Title of the delete-card confirmation dialog"
     },
-    "deleteCardConfirm": "Are you sure you want to delete this card?",
+    "deleteCardConfirm": "Tem certeza de que deseja excluir esta cartela?",
     "@deleteCardConfirm": {
         "description": "Body of the delete-card confirmation dialog"
     },
@@ -106,11 +106,11 @@
     "@delete": {
         "description": "Generic delete button"
     },
-    "shuffleCardTitle": "Shuffle Card",
+    "shuffleCardTitle": "Embaralhar cartela",
     "@shuffleCardTitle": {
         "description": "Title of the shuffle confirmation dialog"
     },
-    "shuffleCardConfirm": "Are you sure you want to shuffle this card? All fields will be unchecked, after shuffling.",
+    "shuffleCardConfirm": "Tem certeza de que deseja embaralhar esta cartela? Todos os campos serão desmarcados depois.",
     "@shuffleCardConfirm": {
         "description": "Body of the shuffle confirmation dialog"
     },
@@ -118,19 +118,19 @@
     "@shuffle": {
         "description": "Confirm button to shuffle the card"
     },
-    "ratingPromptTitle": "Do you like Custom Bingo?",
+    "ratingPromptTitle": "Você gosta do Custom Bingo?",
     "@ratingPromptTitle": {
         "description": "Title of the dialog shown before asking for an app store review"
     },
-    "ratingPromptBody": "If so, a quick store review helps others find it.",
+    "ratingPromptBody": "Se sim, uma avaliação rápida na loja ajuda outras pessoas a encontrá-lo.",
     "@ratingPromptBody": {
         "description": "Body of the dialog shown before asking for an app store review"
     },
-    "ratingPromptNo": "Not really",
+    "ratingPromptNo": "Não muito",
     "@ratingPromptNo": {
         "description": "Dismiss button for the rating prompt dialog"
     },
-    "ratingPromptYes": "Yes, I like it",
+    "ratingPromptYes": "Sim, gosto",
     "@ratingPromptYes": {
         "description": "Confirm button that continues to the native app store review flow"
     },
@@ -142,7 +142,7 @@
     "@boardActionEditBoard": {
         "description": "Menu item that opens the board edit flow from the board action bar"
     },
-    "boardActionAddPreMadeItems": "Add pre-made items",
+    "boardActionAddPreMadeItems": "Adicionar itens prontos",
     "@boardActionAddPreMadeItems": {
         "description": "Debug menu item placeholder for filling a board with pre-made items"
     },
@@ -154,11 +154,11 @@
     "@edit": {
         "description": "Edit menu item in a cell's context menu"
     },
-    "markDone": "Mark Done",
+    "markDone": "Marcar como feito",
     "@markDone": {
         "description": "Cell context menu item: mark this cell as done"
     },
-    "markNotDone": "Mark Not Done",
+    "markNotDone": "Marcar como não feito",
     "@markNotDone": {
         "description": "Cell context menu item: clear the done state"
     },
@@ -166,15 +166,53 @@
     "@newCardMenuItem": {
         "description": "Menu item that opens the new-card screen"
     },
+    "allBoardsMenuItem": "Todas as cartelas",
+    "@allBoardsMenuItem": {
+        "description": "Menu item that opens the list of all saved boards"
+    },
     "yourCardsHeader": "As suas cartelas",
     "@yourCardsHeader": {
         "description": "Section header in the popup menu listing saved cards"
+    },
+    "noBoardsYet": "Ainda não há cartelas",
+    "@noBoardsYet": {
+        "description": "Empty-state title shown when there are no saved boards"
+    },
+    "pageNotFoundTitle": "Página não encontrada",
+    "@pageNotFoundTitle": {
+        "description": "Title shown on the fallback route when a page cannot be found"
+    },
+    "homeButton": "Início",
+    "@homeButton": {
+        "description": "Button that navigates back to the home screen"
+    },
+    "revenueCatUserIdLabel": "ID de usuário do RevenueCat: {userId}",
+    "@revenueCatUserIdLabel": {
+        "description": "Debug settings label showing the RevenueCat user id",
+        "placeholders": {
+            "userId": {
+                "type": "String",
+                "example": "abc123"
+            }
+        }
+    },
+    "copyRevenueCatUserIdTooltip": "Copiar ID de usuário do RevenueCat",
+    "@copyRevenueCatUserIdTooltip": {
+        "description": "Tooltip for copying the RevenueCat user id from debug settings"
+    },
+    "revenueCatUserIdCopiedToast": "ID de usuário do RevenueCat copiado.",
+    "@revenueCatUserIdCopiedToast": {
+        "description": "Toast shown after copying the RevenueCat user id"
     },
     "settingsHeader": "Definições",
     "@settingsHeader": {
         "description": "Section header in the popup menu"
     },
-    "appearanceMenuItem": "Appearance",
+    "clearSettingsMenuItem": "Limpar definições",
+    "@clearSettingsMenuItem": {
+        "description": "Debug menu item that clears saved settings"
+    },
+    "appearanceMenuItem": "Aparência",
     "@appearanceMenuItem": {
         "description": "Menu item that opens the appearance settings screen"
     },
@@ -254,63 +292,63 @@
     "@enableConfettiSettingsDescription": {
         "description": "Settings helper text for the confetti preference switch"
     },
-    "preMadeTilesTitle": "Pre-made tiles",
+    "preMadeTilesTitle": "Casas prontas",
     "@preMadeTilesTitle": {
         "description": "Title of the pre-made tiles settings screen and menu entry"
     },
-    "preMadeTilesSettingsDescription": "Create reusable tile text for future boards.",
+    "preMadeTilesSettingsDescription": "Crie textos reutilizáveis para futuros tabuleiros.",
     "@preMadeTilesSettingsDescription": {
         "description": "Settings entry helper text for pre-made tiles"
     },
-    "preMadeTilesDescription": "Create reusable bingo entries here. When you create a new board, you can add them without typing everything again.",
+    "preMadeTilesDescription": "Crie entradas de bingo reutilizáveis aqui. Ao criar um novo tabuleiro, você pode adicioná-las sem digitar tudo de novo.",
     "@preMadeTilesDescription": {
         "description": "Description shown below the pre-made tiles screen title"
     },
-    "preMadeTilesSelectMode": "Select",
+    "preMadeTilesSelectMode": "Selecionar",
     "@preMadeTilesSelectMode": {
         "description": "Segmented control label for selecting pre-made tiles"
     },
-    "preMadeTilesEditMode": "Edit",
+    "preMadeTilesEditMode": "Editar",
     "@preMadeTilesEditMode": {
         "description": "Segmented control label for editing pre-made tiles"
     },
-    "preMadeTileHint": "Tile text",
+    "preMadeTileHint": "Texto da casa",
     "@preMadeTileHint": {
         "description": "Placeholder for a pre-made tile text field"
     },
-    "preMadeTilesAdd": "Add tile",
+    "preMadeTilesAdd": "Adicionar casa",
     "@preMadeTilesAdd": {
         "description": "Accessible label and tooltip for adding a pre-made tile"
     },
-    "preMadeTilesDelete": "Delete tile",
+    "preMadeTilesDelete": "Excluir casa",
     "@preMadeTilesDelete": {
         "description": "Accessible label and tooltip for deleting a pre-made tile"
     },
-    "preMadeTilesSelectAll": "Un/select all",
+    "preMadeTilesSelectAll": "Selecionar/desmarcar tudo",
     "@preMadeTilesSelectAll": {
         "description": "Checkbox label for toggling all pre-made tile selections"
     },
-    "preMadeTilesSelectNone": "Select none",
+    "preMadeTilesSelectNone": "Não selecionar nada",
     "@preMadeTilesSelectNone": {
         "description": "Button label for clearing all selected pre-made tiles"
     },
-    "preMadeTilesApply": "Apply",
+    "preMadeTilesApply": "Aplicar",
     "@preMadeTilesApply": {
         "description": "Button label for applying selected pre-made tiles to a board"
     },
-    "preMadeTilesReplaceItems": "Replace items",
+    "preMadeTilesReplaceItems": "Substituir itens",
     "@preMadeTilesReplaceItems": {
         "description": "Button label for replacing current board items with selected pre-made items"
     },
-    "preMadeTilesFillItems": "Fill items",
+    "preMadeTilesFillItems": "Preencher itens",
     "@preMadeTilesFillItems": {
         "description": "Button label for filling empty board items with selected pre-made items"
     },
-    "preMadeTilesBoardActionHelp": "Replace swaps the board entries with a random draw from your selection. Fill only adds items to empty tiles. On odd boards, the center tile stays in place.",
+    "preMadeTilesBoardActionHelp": "Substituir troca as entradas do tabuleiro por um sorteio da sua seleção. Preencher só adiciona itens às casas vazias. Em tabuleiros ímpares, a casa central permanece.",
     "@preMadeTilesBoardActionHelp": {
         "description": "Helper text explaining replace and fill actions for pre-made items on an existing board"
     },
-    "preMadeTilesSelectedCount": "{selected} / {total} selected",
+    "preMadeTilesSelectedCount": "{selected} / {total} selecionadas",
     "@preMadeTilesSelectedCount": {
         "description": "Count of selected pre-made tiles",
         "placeholders": {
@@ -324,135 +362,135 @@
             }
         }
     },
-    "preMadeTilesEmptyTitle": "No tiles yet",
+    "preMadeTilesEmptyTitle": "Ainda não há casas",
     "@preMadeTilesEmptyTitle": {
         "description": "Empty-state title for the pre-made tiles screen"
     },
-    "preMadeTilesEmptyBody": "Add a tile to start building a reusable list.",
+    "preMadeTilesEmptyBody": "Adicione uma casa para começar uma lista reutilizável.",
     "@preMadeTilesEmptyBody": {
         "description": "Empty-state helper text for the pre-made tiles screen"
     },
-    "proposeFeatures": "Propose Features",
+    "proposeFeatures": "Propor recursos",
     "@proposeFeatures": {
         "description": "Menu item that opens the UserOrient feedback board"
     },
-    "proposeFeaturesSettingsDescription": "Vote on ideas and suggest what to build next.",
+    "proposeFeaturesSettingsDescription": "Vote em ideias e sugira o que criar a seguir.",
     "@proposeFeaturesSettingsDescription": {
         "description": "Settings helper text for the feature request entry"
     },
-    "supportMeDirectly": "Support the developer",
+    "supportMeDirectly": "Apoiar o desenvolvedor",
     "@supportMeDirectly": {
         "description": "Menu item that opens the direct-support paywall"
     },
-    "supportMeDirectlySettingsDescription": "Help fund development and keep the app improving.",
+    "supportMeDirectlySettingsDescription": "Ajude a financiar o desenvolvimento e manter o app melhorando.",
     "@supportMeDirectlySettingsDescription": {
         "description": "Settings helper text for the direct support entry"
     },
-    "supportCarouselProTitle": "Support Custom Bingo",
+    "supportCarouselProTitle": "Apoie o Custom Bingo",
     "@supportCarouselProTitle": {
         "description": "Title of the home-screen support carousel item that opens the paywall"
     },
-    "supportCarouselProSubtitle": "Unlock bonus colors and help keep the app independent.",
+    "supportCarouselProSubtitle": "Desbloqueie cores extras e ajude a manter o app independente.",
     "@supportCarouselProSubtitle": {
         "description": "Subtitle of the home-screen support carousel item that opens the paywall"
     },
-    "supportCarouselRateTitle": "Enjoying the app?",
+    "supportCarouselRateTitle": "Está gostando do app?",
     "@supportCarouselRateTitle": {
         "description": "Title of the home-screen support carousel item that asks for a store review"
     },
-    "supportCarouselRateSubtitle": "A quick review helps more people find Custom Bingo.",
+    "supportCarouselRateSubtitle": "Uma avaliação rápida ajuda mais pessoas a encontrarem o Custom Bingo.",
     "@supportCarouselRateSubtitle": {
         "description": "Subtitle of the home-screen support carousel item that asks for a store review"
     },
-    "rateTheApp": "Rate the app",
+    "rateTheApp": "Avaliar o app",
     "@rateTheApp": {
         "description": "Settings entry that opens the native store rating dialog"
     },
-    "rateTheAppSettingsDescription": "Open the store rating prompt.",
+    "rateTheAppSettingsDescription": "Abrir o pedido de avaliação na loja.",
     "@rateTheAppSettingsDescription": {
         "description": "Settings helper text for the app rating entry"
     },
-    "contactMe": "Contact me",
+    "contactMe": "Entrar em contato",
     "@contactMe": {
         "description": "Settings entry that opens an email composer"
     },
-    "contactMeSettingsDescription": "Send feedback, questions, or bug reports by email.",
+    "contactMeSettingsDescription": "Envie comentários, perguntas ou relatos de bugs por email.",
     "@contactMeSettingsDescription": {
         "description": "Settings helper text for the contact email entry"
     },
-    "paywallTitle": "Support Custom Bingo",
+    "paywallTitle": "Apoie o Custom Bingo",
     "@paywallTitle": {
         "description": "AppBar title of the direct-support paywall"
     },
-    "paywallThankYouTitle": "Thank you",
+    "paywallThankYouTitle": "Obrigado",
     "@paywallThankYouTitle": {
         "description": "Paywall title shown after Pro access is active"
     },
-    "paywallSupportTitle": "Support Custom Bingo",
+    "paywallSupportTitle": "Apoie o Custom Bingo",
     "@paywallSupportTitle": {
         "description": "Main title on the direct-support paywall"
     },
-    "paywallSupportBody": "This purchase supports me, the developer, directly. You get my gratitude and a few small bonus things for your boards.",
+    "paywallSupportBody": "Esta compra me apoia diretamente, o desenvolvedor. Você recebe minha gratidão e alguns pequenos extras para seus tabuleiros.",
     "@paywallSupportBody": {
         "description": "Main body copy on the direct-support paywall"
     },
-    "paywallBonusGratitude": "My gratitude, sincerely.",
+    "paywallBonusGratitude": "Minha gratidão, de verdade.",
     "@paywallBonusGratitude": {
         "description": "First benefit line on the direct-support paywall"
     },
-    "paywallBonusColors": "A few extra board colors.",
+    "paywallBonusColors": "Algumas cores extras para tabuleiros.",
     "@paywallBonusColors": {
         "description": "Second benefit line on the direct-support paywall"
     },
-    "paywallBonusExtras": "Small supporter extras over time.",
+    "paywallBonusExtras": "Pequenos extras de apoiador ao longo do tempo.",
     "@paywallBonusExtras": {
         "description": "Third benefit line on the direct-support paywall"
     },
-    "paywallFreeForever": "No one ever needs to pay for this app. Custom Bingo stays usable for everyone.",
+    "paywallFreeForever": "Ninguém precisa pagar por este app. O Custom Bingo continua utilizável para todos.",
     "@paywallFreeForever": {
         "description": "Footer reassurance on the direct-support paywall"
     },
-    "paywallLoadingPrice": "Loading price",
+    "paywallLoadingPrice": "Carregando preço",
     "@paywallLoadingPrice": {
         "description": "Placeholder shown while the paywall price is loading"
     },
-    "paywallUnavailable": "Unavailable",
+    "paywallUnavailable": "Indisponível",
     "@paywallUnavailable": {
         "description": "Paywall price/button text when purchases are unavailable"
     },
-    "paywallSupportOnce": "Support once",
+    "paywallSupportOnce": "Apoiar uma vez",
     "@paywallSupportOnce": {
         "description": "Purchase button label on the direct-support paywall"
     },
-    "paywallRestorePurchase": "Restore purchase",
+    "paywallRestorePurchase": "Restaurar compra",
     "@paywallRestorePurchase": {
         "description": "Restore button label on the direct-support paywall"
     },
-    "paywallProActiveToast": "Custom Bingo Pro is active.",
+    "paywallProActiveToast": "Custom Bingo Pro está ativo.",
     "@paywallProActiveToast": {
         "description": "Toast shown after a successful Pro purchase"
     },
-    "paywallPurchaseInactiveToast": "Purchase finished, but Pro is not active.",
+    "paywallPurchaseInactiveToast": "A compra terminou, mas o Pro não está ativo.",
     "@paywallPurchaseInactiveToast": {
         "description": "Toast shown if a purchase returns without Pro access"
     },
-    "paywallProRestoredToast": "Custom Bingo Pro restored.",
+    "paywallProRestoredToast": "Custom Bingo Pro restaurado.",
     "@paywallProRestoredToast": {
         "description": "Toast shown after restoring Pro access"
     },
-    "paywallNoPurchaseFoundToast": "No Pro purchase found.",
+    "paywallNoPurchaseFoundToast": "Nenhuma compra Pro encontrada.",
     "@paywallNoPurchaseFoundToast": {
         "description": "Toast shown when restore finds no Pro access"
     },
-    "paywallPurchasesUnavailable": "Purchases are unavailable right now.",
+    "paywallPurchasesUnavailable": "As compras estão indisponíveis no momento.",
     "@paywallPurchasesUnavailable": {
         "description": "Fallback error text for a paywall purchase error"
     },
-    "paywallPlatformUnavailable": "Purchases are unavailable on this platform.",
+    "paywallPlatformUnavailable": "As compras não estão disponíveis nesta plataforma.",
     "@paywallPlatformUnavailable": {
         "description": "Fallback paywall text when purchases are not configured for the platform"
     },
-    "paywallCouldNotLoad": "Could not load purchase information.",
+    "paywallCouldNotLoad": "Não foi possível carregar as informações de compra.",
     "@paywallCouldNotLoad": {
         "description": "Fallback paywall error text for an unknown purchase loading error"
     },
@@ -460,7 +498,7 @@
     "@shareTitle": {
         "description": "Title of the share dialog"
     },
-    "shareDialogPrompt": "How would you like to share?",
+    "shareDialogPrompt": "Como você gostaria de compartilhar?",
     "@shareDialogPrompt": {
         "description": "Section header above the two share options"
     },
@@ -468,7 +506,7 @@
     "@shareImageOptionTitle": {
         "description": "Title of the image-share option in the share dialog"
     },
-    "shareImageOptionHelper": "Send a picture of your card. Anyone can see it — even without the app.",
+    "shareImageOptionHelper": "Envie uma imagem da sua cartela. Qualquer pessoa pode ver, mesmo sem o app.",
     "@shareImageOptionHelper": {
         "description": "Helper text explaining what 'Share as image' does"
     },
@@ -480,15 +518,15 @@
     "@shareInviteOptionTitle": {
         "description": "Title of the play-together invite option"
     },
-    "shareInviteOptionHelper": "Send this link to your friends who also have this app installed. They get the same card and you can play together.",
+    "shareInviteOptionHelper": "Envie este link para amigos que também têm este app instalado. Eles recebem a mesma cartela e vocês podem jogar juntos.",
     "@shareInviteOptionHelper": {
         "description": "Helper text explaining what the invite link does"
     },
-    "shareInviteIncludeMarks": "Include my checkmarks",
+    "shareInviteIncludeMarks": "Incluir minhas marcações",
     "@shareInviteIncludeMarks": {
         "description": "Toggle label: include the sender's marks in the invite"
     },
-    "shareInviteIncludeMarksHelper": "When on, your friends will see what you've already crossed off.",
+    "shareInviteIncludeMarksHelper": "Quando ativado, seus amigos verão o que você já marcou.",
     "@shareInviteIncludeMarksHelper": {
         "description": "Helper text under the include-checkmarks toggle"
     },
@@ -514,15 +552,15 @@
     "@close": {
         "description": "Generic close button"
     },
-    "shareSubject": "Bingo Card",
+    "shareSubject": "Cartela de bingo",
     "@shareSubject": {
         "description": "Subject/title used by the system share sheet"
     },
-    "importTitle": "A friend shared a bingo card with you",
+    "importTitle": "Um amigo compartilhou uma cartela de bingo com você",
     "@importTitle": {
         "description": "Title of the import-card screen shown to the receiver"
     },
-    "importBody": "Add it to your cards so you can play along?",
+    "importBody": "Adicionar às suas cartelas para jogar junto?",
     "@importBody": {
         "description": "Body of the import-card screen"
     },
@@ -534,7 +572,7 @@
     "@importCancel": {
         "description": "Cancel button on the import-card screen"
     },
-    "importCollisionToast": "You already had a card with this name, so I added it as \"{newName}\".",
+    "importCollisionToast": "Você já tinha uma cartela com este nome, então eu a adicionei como \"{newName}\".",
     "@importCollisionToast": {
         "description": "Toast shown after silently renaming an imported card to avoid a collision",
         "placeholders": {
@@ -544,15 +582,15 @@
             }
         }
     },
-    "importBadLinkToast": "Sorry, this invite couldn't be opened. Ask your friend to send it again.",
+    "importBadLinkToast": "Desculpe, este convite não pôde ser aberto. Peça ao seu amigo para enviá-lo novamente.",
     "@importBadLinkToast": {
         "description": "Toast shown when an invite link is malformed"
     },
-    "importOutdatedAppToast": "Update the app to open this invite.",
+    "importOutdatedAppToast": "Atualize o app para abrir este convite.",
     "@importOutdatedAppToast": {
         "description": "Toast shown when an invite payload uses a newer schema"
     },
-    "toastInfo": "Info",
+    "toastInfo": "Informação",
     "@toastInfo": {
         "description": "Title of an informational toast"
     },
@@ -582,55 +620,55 @@
             }
         }
     },
-    "screenshotCaptionPlaying": "Just a simple app to create bingo board.\n\nNo signup, no ads, fully free to use.",
+    "screenshotCaptionPlaying": "Um app simples para criar tabuleiros de bingo.\\n\\nSem cadastro, sem anúncios e totalmente grátis.",
     "@screenshotCaptionPlaying": {
         "description": "Promotional caption for the screenshot showing a played bingo board"
     },
-    "screenshotCaptionCreate": "Literally just 2 screens to create a bingo grid.",
+    "screenshotCaptionCreate": "Literalmente só duas telas para criar uma grade de bingo.",
     "@screenshotCaptionCreate": {
         "description": "Promotional caption for the screenshot showing the new-board screen"
     },
-    "screenshotCaptionLocked": "That's it.",
+    "screenshotCaptionLocked": "É isso.",
     "@screenshotCaptionLocked": {
         "description": "Promotional caption for the screenshot showing the locked board"
     },
-    "screenshotBoardName": "David's Wedding",
+    "screenshotBoardName": "Casamento do David",
     "@screenshotBoardName": {
         "description": "Sample bingo board name used in generated screenshots"
     },
-    "screenshotTilePhoneDuringVows": "Phone during vows",
+    "screenshotTilePhoneDuringVows": "Celular durante os votos",
     "@screenshotTilePhoneDuringVows": {
         "description": "Sample bingo tile text used in generated screenshots"
     },
-    "screenshotTileChampagneSpilled": "Champagne spilled",
+    "screenshotTileChampagneSpilled": "Champanhe derramado",
     "@screenshotTileChampagneSpilled": {
         "description": "Sample bingo tile text used in generated screenshots"
     },
-    "screenshotTileSpeechTears": "Speech tears",
+    "screenshotTileSpeechTears": "Lágrimas no discurso",
     "@screenshotTileSpeechTears": {
         "description": "Sample bingo tile text used in generated screenshots"
     },
-    "screenshotTileDramaticEntrance": "Dramatic entrance",
+    "screenshotTileDramaticEntrance": "Entrada dramática",
     "@screenshotTileDramaticEntrance": {
         "description": "Sample bingo tile text used in generated screenshots"
     },
-    "screenshotTileKidsDanceFloor": "Kids take the dance floor",
+    "screenshotTileKidsDanceFloor": "Crianças na pista",
     "@screenshotTileKidsDanceFloor": {
         "description": "Sample bingo tile text used in generated screenshots"
     },
-    "screenshotTileGuestToast": "Guest gives a toast",
+    "screenshotTileGuestToast": "Convidado faz um brinde",
     "@screenshotTileGuestToast": {
         "description": "Sample bingo tile text used in generated screenshots"
     },
-    "screenshotTileCrowdClapsEarly": "Crowd claps early",
+    "screenshotTileCrowdClapsEarly": "Aplausos cedo demais",
     "@screenshotTileCrowdClapsEarly": {
         "description": "Sample bingo tile text used in generated screenshots"
     },
-    "screenshotTileDjClassic": "DJ plays a classic",
+    "screenshotTileDjClassic": "DJ toca um clássico",
     "@screenshotTileDjClassic": {
         "description": "Sample bingo tile text used in generated screenshots"
     },
-    "screenshotTileGroupPhotoChaos": "Group photo chaos",
+    "screenshotTileGroupPhotoChaos": "Caos na foto de grupo",
     "@screenshotTileGroupPhotoChaos": {
         "description": "Sample bingo tile text used in generated screenshots"
     }

--- a/lib/l10n/arb/app_pt.arb
+++ b/lib/l10n/arb/app_pt.arb
@@ -1,0 +1,637 @@
+{
+    "@@locale": "pt",
+    "newCardTitle": "Criar nova cartela de bingo",
+    "@newCardTitle": {
+        "description": "AppBar title of the new-card screen"
+    },
+    "editCardTitle": "Editar cartela de bingo",
+    "@editCardTitle": {
+        "description": "AppBar title of the edit-card screen"
+    },
+    "cardNameLabel": "Nome da cartela *",
+    "@cardNameLabel": {
+        "description": "Label of the card-name text field"
+    },
+    "cardNameHint": "Dê um nome à sua cartela de bingo",
+    "@cardNameHint": {
+        "description": "Placeholder hint for the card-name text field"
+    },
+    "createCardButton": "Criar cartela",
+    "@createCardButton": {
+        "description": "Confirm button on the new-card screen"
+    },
+    "updateCardButton": "Atualizar cartela",
+    "@updateCardButton": {
+        "description": "Confirm button on the edit-card screen"
+    },
+    "newBoardPreMadeSectionTitle": "Your pre-made items",
+    "@newBoardPreMadeSectionTitle": {
+        "description": "Expandable section title for pre-made items on the new-board screen"
+    },
+    "newBoardPreMadeButton": "Start with pre-made items",
+    "@newBoardPreMadeButton": {
+        "description": "Button that opens pre-made item selection from the new-board screen"
+    },
+    "newBoardPreMadeChangeButton": "Change pre-made items",
+    "@newBoardPreMadeChangeButton": {
+        "description": "Button that reopens pre-made item selection after items have been applied"
+    },
+    "newBoardPreMadeClearButton": "Clear pre-made items",
+    "@newBoardPreMadeClearButton": {
+        "description": "Button that clears applied pre-made entries from the new-board form"
+    },
+    "newBoardPreMadeAppliedCount": "{count} pre-made entries applied",
+    "@newBoardPreMadeAppliedCount": {
+        "description": "Summary of how many pre-made entries are applied to the new-board form",
+        "placeholders": {
+            "count": {
+                "type": "int",
+                "example": "40"
+            }
+        }
+    },
+    "newBoardPreMadeFullSummary": "{used} will be drawn at random for this board.",
+    "@newBoardPreMadeFullSummary": {
+        "description": "Summary when applied pre-made entries can fill the new board",
+        "placeholders": {
+            "used": {
+                "type": "int",
+                "example": "25"
+            }
+        }
+    },
+    "newBoardPreMadePartialSummary": "{used} cells will be filled. {blank} will stay blank.",
+    "@newBoardPreMadePartialSummary": {
+        "description": "Summary when applied pre-made entries are fewer than the board cells",
+        "placeholders": {
+            "used": {
+                "type": "int",
+                "example": "10"
+            },
+            "blank": {
+                "type": "int",
+                "example": "15"
+            }
+        }
+    },
+    "defaultCardName": "Cartela de bingo",
+    "@defaultCardName": {
+        "description": "Fallback title shown when a card has no name"
+    },
+    "toggleHint": "Prima sem soltar para marcar uma casa",
+    "@toggleHint": {
+        "description": "Hint banner above the bingo grid"
+    },
+    "editingHintBefore": "Press the lock icon",
+    "@editingHintBefore": {
+        "description": "First half of the hint that explains the lock toggle. The lock icon is rendered between the two halves."
+    },
+    "editingHintAfter": " to make the fields not editable anymore.",
+    "@editingHintAfter": {
+        "description": "Second half of the lock-toggle hint, rendered after the lock icon."
+    },
+    "deleteCardTitle": "Delete Card",
+    "@deleteCardTitle": {
+        "description": "Title of the delete-card confirmation dialog"
+    },
+    "deleteCardConfirm": "Are you sure you want to delete this card?",
+    "@deleteCardConfirm": {
+        "description": "Body of the delete-card confirmation dialog"
+    },
+    "cancel": "Cancelar",
+    "@cancel": {
+        "description": "Generic cancel button"
+    },
+    "delete": "Eliminar",
+    "@delete": {
+        "description": "Generic delete button"
+    },
+    "shuffleCardTitle": "Shuffle Card",
+    "@shuffleCardTitle": {
+        "description": "Title of the shuffle confirmation dialog"
+    },
+    "shuffleCardConfirm": "Are you sure you want to shuffle this card? All fields will be unchecked, after shuffling.",
+    "@shuffleCardConfirm": {
+        "description": "Body of the shuffle confirmation dialog"
+    },
+    "shuffle": "Baralhar",
+    "@shuffle": {
+        "description": "Confirm button to shuffle the card"
+    },
+    "ratingPromptTitle": "Do you like Custom Bingo?",
+    "@ratingPromptTitle": {
+        "description": "Title of the dialog shown before asking for an app store review"
+    },
+    "ratingPromptBody": "If so, a quick store review helps others find it.",
+    "@ratingPromptBody": {
+        "description": "Body of the dialog shown before asking for an app store review"
+    },
+    "ratingPromptNo": "Not really",
+    "@ratingPromptNo": {
+        "description": "Dismiss button for the rating prompt dialog"
+    },
+    "ratingPromptYes": "Yes, I like it",
+    "@ratingPromptYes": {
+        "description": "Confirm button that continues to the native app store review flow"
+    },
+    "boardActionShare": "Partilhar",
+    "@boardActionShare": {
+        "description": "Menu item that opens the share dialog from the board action bar"
+    },
+    "boardActionEditBoard": "Editar cartela",
+    "@boardActionEditBoard": {
+        "description": "Menu item that opens the board edit flow from the board action bar"
+    },
+    "boardActionAddPreMadeItems": "Add pre-made items",
+    "@boardActionAddPreMadeItems": {
+        "description": "Debug menu item placeholder for filling a board with pre-made items"
+    },
+    "cellHint": "Introduzir texto…",
+    "@cellHint": {
+        "description": "Placeholder for an empty bingo cell"
+    },
+    "edit": "Editar",
+    "@edit": {
+        "description": "Edit menu item in a cell's context menu"
+    },
+    "markDone": "Mark Done",
+    "@markDone": {
+        "description": "Cell context menu item: mark this cell as done"
+    },
+    "markNotDone": "Mark Not Done",
+    "@markNotDone": {
+        "description": "Cell context menu item: clear the done state"
+    },
+    "newCardMenuItem": "Nova cartela de bingo",
+    "@newCardMenuItem": {
+        "description": "Menu item that opens the new-card screen"
+    },
+    "yourCardsHeader": "As suas cartelas",
+    "@yourCardsHeader": {
+        "description": "Section header in the popup menu listing saved cards"
+    },
+    "settingsHeader": "Definições",
+    "@settingsHeader": {
+        "description": "Section header in the popup menu"
+    },
+    "appearanceMenuItem": "Appearance",
+    "@appearanceMenuItem": {
+        "description": "Menu item that opens the appearance settings screen"
+    },
+    "settingsAppearanceSection": "Aparência",
+    "@settingsAppearanceSection": {
+        "description": "Section title for appearance settings"
+    },
+    "settingsPreferencesSection": "Preferências",
+    "@settingsPreferencesSection": {
+        "description": "Section title for general preference settings"
+    },
+    "settingsBoardsSection": "Cartelas",
+    "@settingsBoardsSection": {
+        "description": "Section title for board-related settings"
+    },
+    "settingsHelpSection": "Mais",
+    "@settingsHelpSection": {
+        "description": "Section title for additional settings, help, and support entries"
+    },
+    "settingsSupportSection": "Apoio",
+    "@settingsSupportSection": {
+        "description": "Section title for supporting the developer"
+    },
+    "themeColorLabel": "Cor do tema",
+    "@themeColorLabel": {
+        "description": "Label above the theme color selector in settings"
+    },
+    "themeColorSettingsDescription": "Escolha a paleta usada em toda a app.",
+    "@themeColorSettingsDescription": {
+        "description": "Settings helper text for the theme color selector"
+    },
+    "languageSettingsTitle": "Idioma",
+    "@languageSettingsTitle": {
+        "description": "Settings tile title for choosing the app language"
+    },
+    "languageSettingsSelectorLabel": "Idioma da app",
+    "@languageSettingsSelectorLabel": {
+        "description": "Label above the language dropdown in settings"
+    },
+    "languageSettingsSystemOption": "Padrão do sistema ({language})",
+    "@languageSettingsSystemOption": {
+        "description": "Dropdown option that makes the app follow the phone/system language. The placeholder is the current phone language display name.",
+        "placeholders": {
+            "language": {
+                "type": "String",
+                "example": "Deutsch"
+            }
+        }
+    },
+    "languageSettingsSystemDescription": "Segue o idioma do telefone: {language}.",
+    "@languageSettingsSystemDescription": {
+        "description": "Settings helper text when no manual app language override is selected. The placeholder is the current phone language display name.",
+        "placeholders": {
+            "language": {
+                "type": "String",
+                "example": "Deutsch"
+            }
+        }
+    },
+    "languageSettingsOverrideDescription": "Usar este idioma em vez do idioma do telefone.",
+    "@languageSettingsOverrideDescription": {
+        "description": "Settings helper text when a manual app language override is selected"
+    },
+    "darkModeLabel": "Modo escuro",
+    "@darkModeLabel": {
+        "description": "Label for the dark mode switch in settings"
+    },
+    "darkModeSettingsDescription": "Usar uma interface mais escura.",
+    "@darkModeSettingsDescription": {
+        "description": "Settings helper text for the dark mode switch"
+    },
+    "enableConfettiLabel": "Confete",
+    "@enableConfettiLabel": {
+        "description": "Label for the confetti preference switch"
+    },
+    "enableConfettiSettingsDescription": "Mostrar uma celebração ao completar um bingo.",
+    "@enableConfettiSettingsDescription": {
+        "description": "Settings helper text for the confetti preference switch"
+    },
+    "preMadeTilesTitle": "Pre-made tiles",
+    "@preMadeTilesTitle": {
+        "description": "Title of the pre-made tiles settings screen and menu entry"
+    },
+    "preMadeTilesSettingsDescription": "Create reusable tile text for future boards.",
+    "@preMadeTilesSettingsDescription": {
+        "description": "Settings entry helper text for pre-made tiles"
+    },
+    "preMadeTilesDescription": "Create reusable bingo entries here. When you create a new board, you can add them without typing everything again.",
+    "@preMadeTilesDescription": {
+        "description": "Description shown below the pre-made tiles screen title"
+    },
+    "preMadeTilesSelectMode": "Select",
+    "@preMadeTilesSelectMode": {
+        "description": "Segmented control label for selecting pre-made tiles"
+    },
+    "preMadeTilesEditMode": "Edit",
+    "@preMadeTilesEditMode": {
+        "description": "Segmented control label for editing pre-made tiles"
+    },
+    "preMadeTileHint": "Tile text",
+    "@preMadeTileHint": {
+        "description": "Placeholder for a pre-made tile text field"
+    },
+    "preMadeTilesAdd": "Add tile",
+    "@preMadeTilesAdd": {
+        "description": "Accessible label and tooltip for adding a pre-made tile"
+    },
+    "preMadeTilesDelete": "Delete tile",
+    "@preMadeTilesDelete": {
+        "description": "Accessible label and tooltip for deleting a pre-made tile"
+    },
+    "preMadeTilesSelectAll": "Un/select all",
+    "@preMadeTilesSelectAll": {
+        "description": "Checkbox label for toggling all pre-made tile selections"
+    },
+    "preMadeTilesSelectNone": "Select none",
+    "@preMadeTilesSelectNone": {
+        "description": "Button label for clearing all selected pre-made tiles"
+    },
+    "preMadeTilesApply": "Apply",
+    "@preMadeTilesApply": {
+        "description": "Button label for applying selected pre-made tiles to a board"
+    },
+    "preMadeTilesReplaceItems": "Replace items",
+    "@preMadeTilesReplaceItems": {
+        "description": "Button label for replacing current board items with selected pre-made items"
+    },
+    "preMadeTilesFillItems": "Fill items",
+    "@preMadeTilesFillItems": {
+        "description": "Button label for filling empty board items with selected pre-made items"
+    },
+    "preMadeTilesBoardActionHelp": "Replace swaps the board entries with a random draw from your selection. Fill only adds items to empty tiles. On odd boards, the center tile stays in place.",
+    "@preMadeTilesBoardActionHelp": {
+        "description": "Helper text explaining replace and fill actions for pre-made items on an existing board"
+    },
+    "preMadeTilesSelectedCount": "{selected} / {total} selected",
+    "@preMadeTilesSelectedCount": {
+        "description": "Count of selected pre-made tiles",
+        "placeholders": {
+            "selected": {
+                "type": "int",
+                "example": "12"
+            },
+            "total": {
+                "type": "int",
+                "example": "24"
+            }
+        }
+    },
+    "preMadeTilesEmptyTitle": "No tiles yet",
+    "@preMadeTilesEmptyTitle": {
+        "description": "Empty-state title for the pre-made tiles screen"
+    },
+    "preMadeTilesEmptyBody": "Add a tile to start building a reusable list.",
+    "@preMadeTilesEmptyBody": {
+        "description": "Empty-state helper text for the pre-made tiles screen"
+    },
+    "proposeFeatures": "Propose Features",
+    "@proposeFeatures": {
+        "description": "Menu item that opens the UserOrient feedback board"
+    },
+    "proposeFeaturesSettingsDescription": "Vote on ideas and suggest what to build next.",
+    "@proposeFeaturesSettingsDescription": {
+        "description": "Settings helper text for the feature request entry"
+    },
+    "supportMeDirectly": "Support the developer",
+    "@supportMeDirectly": {
+        "description": "Menu item that opens the direct-support paywall"
+    },
+    "supportMeDirectlySettingsDescription": "Help fund development and keep the app improving.",
+    "@supportMeDirectlySettingsDescription": {
+        "description": "Settings helper text for the direct support entry"
+    },
+    "supportCarouselProTitle": "Support Custom Bingo",
+    "@supportCarouselProTitle": {
+        "description": "Title of the home-screen support carousel item that opens the paywall"
+    },
+    "supportCarouselProSubtitle": "Unlock bonus colors and help keep the app independent.",
+    "@supportCarouselProSubtitle": {
+        "description": "Subtitle of the home-screen support carousel item that opens the paywall"
+    },
+    "supportCarouselRateTitle": "Enjoying the app?",
+    "@supportCarouselRateTitle": {
+        "description": "Title of the home-screen support carousel item that asks for a store review"
+    },
+    "supportCarouselRateSubtitle": "A quick review helps more people find Custom Bingo.",
+    "@supportCarouselRateSubtitle": {
+        "description": "Subtitle of the home-screen support carousel item that asks for a store review"
+    },
+    "rateTheApp": "Rate the app",
+    "@rateTheApp": {
+        "description": "Settings entry that opens the native store rating dialog"
+    },
+    "rateTheAppSettingsDescription": "Open the store rating prompt.",
+    "@rateTheAppSettingsDescription": {
+        "description": "Settings helper text for the app rating entry"
+    },
+    "contactMe": "Contact me",
+    "@contactMe": {
+        "description": "Settings entry that opens an email composer"
+    },
+    "contactMeSettingsDescription": "Send feedback, questions, or bug reports by email.",
+    "@contactMeSettingsDescription": {
+        "description": "Settings helper text for the contact email entry"
+    },
+    "paywallTitle": "Support Custom Bingo",
+    "@paywallTitle": {
+        "description": "AppBar title of the direct-support paywall"
+    },
+    "paywallThankYouTitle": "Thank you",
+    "@paywallThankYouTitle": {
+        "description": "Paywall title shown after Pro access is active"
+    },
+    "paywallSupportTitle": "Support Custom Bingo",
+    "@paywallSupportTitle": {
+        "description": "Main title on the direct-support paywall"
+    },
+    "paywallSupportBody": "This purchase supports me, the developer, directly. You get my gratitude and a few small bonus things for your boards.",
+    "@paywallSupportBody": {
+        "description": "Main body copy on the direct-support paywall"
+    },
+    "paywallBonusGratitude": "My gratitude, sincerely.",
+    "@paywallBonusGratitude": {
+        "description": "First benefit line on the direct-support paywall"
+    },
+    "paywallBonusColors": "A few extra board colors.",
+    "@paywallBonusColors": {
+        "description": "Second benefit line on the direct-support paywall"
+    },
+    "paywallBonusExtras": "Small supporter extras over time.",
+    "@paywallBonusExtras": {
+        "description": "Third benefit line on the direct-support paywall"
+    },
+    "paywallFreeForever": "No one ever needs to pay for this app. Custom Bingo stays usable for everyone.",
+    "@paywallFreeForever": {
+        "description": "Footer reassurance on the direct-support paywall"
+    },
+    "paywallLoadingPrice": "Loading price",
+    "@paywallLoadingPrice": {
+        "description": "Placeholder shown while the paywall price is loading"
+    },
+    "paywallUnavailable": "Unavailable",
+    "@paywallUnavailable": {
+        "description": "Paywall price/button text when purchases are unavailable"
+    },
+    "paywallSupportOnce": "Support once",
+    "@paywallSupportOnce": {
+        "description": "Purchase button label on the direct-support paywall"
+    },
+    "paywallRestorePurchase": "Restore purchase",
+    "@paywallRestorePurchase": {
+        "description": "Restore button label on the direct-support paywall"
+    },
+    "paywallProActiveToast": "Custom Bingo Pro is active.",
+    "@paywallProActiveToast": {
+        "description": "Toast shown after a successful Pro purchase"
+    },
+    "paywallPurchaseInactiveToast": "Purchase finished, but Pro is not active.",
+    "@paywallPurchaseInactiveToast": {
+        "description": "Toast shown if a purchase returns without Pro access"
+    },
+    "paywallProRestoredToast": "Custom Bingo Pro restored.",
+    "@paywallProRestoredToast": {
+        "description": "Toast shown after restoring Pro access"
+    },
+    "paywallNoPurchaseFoundToast": "No Pro purchase found.",
+    "@paywallNoPurchaseFoundToast": {
+        "description": "Toast shown when restore finds no Pro access"
+    },
+    "paywallPurchasesUnavailable": "Purchases are unavailable right now.",
+    "@paywallPurchasesUnavailable": {
+        "description": "Fallback error text for a paywall purchase error"
+    },
+    "paywallPlatformUnavailable": "Purchases are unavailable on this platform.",
+    "@paywallPlatformUnavailable": {
+        "description": "Fallback paywall text when purchases are not configured for the platform"
+    },
+    "paywallCouldNotLoad": "Could not load purchase information.",
+    "@paywallCouldNotLoad": {
+        "description": "Fallback paywall error text for an unknown purchase loading error"
+    },
+    "shareTitle": "Partilhar a cartela de bingo",
+    "@shareTitle": {
+        "description": "Title of the share dialog"
+    },
+    "shareDialogPrompt": "How would you like to share?",
+    "@shareDialogPrompt": {
+        "description": "Section header above the two share options"
+    },
+    "shareImageOptionTitle": "Partilhar como imagem",
+    "@shareImageOptionTitle": {
+        "description": "Title of the image-share option in the share dialog"
+    },
+    "shareImageOptionHelper": "Send a picture of your card. Anyone can see it — even without the app.",
+    "@shareImageOptionHelper": {
+        "description": "Helper text explaining what 'Share as image' does"
+    },
+    "shareImageOptionButton": "Partilhar imagem",
+    "@shareImageOptionButton": {
+        "description": "Confirm button on the image-share option"
+    },
+    "shareInviteOptionTitle": "Convidar amigos para jogar",
+    "@shareInviteOptionTitle": {
+        "description": "Title of the play-together invite option"
+    },
+    "shareInviteOptionHelper": "Send this link to your friends who also have this app installed. They get the same card and you can play together.",
+    "@shareInviteOptionHelper": {
+        "description": "Helper text explaining what the invite link does"
+    },
+    "shareInviteIncludeMarks": "Include my checkmarks",
+    "@shareInviteIncludeMarks": {
+        "description": "Toggle label: include the sender's marks in the invite"
+    },
+    "shareInviteIncludeMarksHelper": "When on, your friends will see what you've already crossed off.",
+    "@shareInviteIncludeMarksHelper": {
+        "description": "Helper text under the include-checkmarks toggle"
+    },
+    "shareInviteOptionButton": "Enviar convite",
+    "@shareInviteOptionButton": {
+        "description": "Confirm button on the invite-link option"
+    },
+    "shareInviteText": "Joga “{name}” comigo! Abre na app:\n{link}",
+    "@shareInviteText": {
+        "description": "Body text passed to the system share sheet alongside the invite link",
+        "placeholders": {
+            "name": {
+                "type": "String",
+                "example": "Dateline BINGO"
+            },
+            "link": {
+                "type": "String",
+                "example": "https://bingogrid.web.app/import?d=…"
+            }
+        }
+    },
+    "close": "Fechar",
+    "@close": {
+        "description": "Generic close button"
+    },
+    "shareSubject": "Bingo Card",
+    "@shareSubject": {
+        "description": "Subject/title used by the system share sheet"
+    },
+    "importTitle": "A friend shared a bingo card with you",
+    "@importTitle": {
+        "description": "Title of the import-card screen shown to the receiver"
+    },
+    "importBody": "Add it to your cards so you can play along?",
+    "@importBody": {
+        "description": "Body of the import-card screen"
+    },
+    "importConfirm": "Adicionar às minhas cartelas",
+    "@importConfirm": {
+        "description": "Confirm button on the import-card screen"
+    },
+    "importCancel": "Agora não",
+    "@importCancel": {
+        "description": "Cancel button on the import-card screen"
+    },
+    "importCollisionToast": "You already had a card with this name, so I added it as \"{newName}\".",
+    "@importCollisionToast": {
+        "description": "Toast shown after silently renaming an imported card to avoid a collision",
+        "placeholders": {
+            "newName": {
+                "type": "String",
+                "example": "Dateline BINGO (2)"
+            }
+        }
+    },
+    "importBadLinkToast": "Sorry, this invite couldn't be opened. Ask your friend to send it again.",
+    "@importBadLinkToast": {
+        "description": "Toast shown when an invite link is malformed"
+    },
+    "importOutdatedAppToast": "Update the app to open this invite.",
+    "@importOutdatedAppToast": {
+        "description": "Toast shown when an invite payload uses a newer schema"
+    },
+    "toastInfo": "Info",
+    "@toastInfo": {
+        "description": "Title of an informational toast"
+    },
+    "toastSuccess": "Sucesso",
+    "@toastSuccess": {
+        "description": "Title of a success toast"
+    },
+    "toastError": "Erro",
+    "@toastError": {
+        "description": "Title of an error toast"
+    },
+    "lastChangeNever": "Última alteração: nunca",
+    "@lastChangeNever": {
+        "description": "Footer line shown when a card has never been edited"
+    },
+    "lastChange": "Última alteração: {date} {time}",
+    "@lastChange": {
+        "description": "Footer line showing when the card was last edited",
+        "placeholders": {
+            "date": {
+                "type": "String",
+                "example": "5.5.2026"
+            },
+            "time": {
+                "type": "String",
+                "example": "14:30"
+            }
+        }
+    },
+    "screenshotCaptionPlaying": "Just a simple app to create bingo board.\n\nNo signup, no ads, fully free to use.",
+    "@screenshotCaptionPlaying": {
+        "description": "Promotional caption for the screenshot showing a played bingo board"
+    },
+    "screenshotCaptionCreate": "Literally just 2 screens to create a bingo grid.",
+    "@screenshotCaptionCreate": {
+        "description": "Promotional caption for the screenshot showing the new-board screen"
+    },
+    "screenshotCaptionLocked": "That's it.",
+    "@screenshotCaptionLocked": {
+        "description": "Promotional caption for the screenshot showing the locked board"
+    },
+    "screenshotBoardName": "David's Wedding",
+    "@screenshotBoardName": {
+        "description": "Sample bingo board name used in generated screenshots"
+    },
+    "screenshotTilePhoneDuringVows": "Phone during vows",
+    "@screenshotTilePhoneDuringVows": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileChampagneSpilled": "Champagne spilled",
+    "@screenshotTileChampagneSpilled": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileSpeechTears": "Speech tears",
+    "@screenshotTileSpeechTears": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileDramaticEntrance": "Dramatic entrance",
+    "@screenshotTileDramaticEntrance": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileKidsDanceFloor": "Kids take the dance floor",
+    "@screenshotTileKidsDanceFloor": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileGuestToast": "Guest gives a toast",
+    "@screenshotTileGuestToast": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileCrowdClapsEarly": "Crowd claps early",
+    "@screenshotTileCrowdClapsEarly": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileDjClassic": "DJ plays a classic",
+    "@screenshotTileDjClassic": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileGroupPhotoChaos": "Group photo chaos",
+    "@screenshotTileGroupPhotoChaos": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    }
+}

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -1,0 +1,637 @@
+{
+    "@@locale": "zh",
+    "newCardTitle": "创建新的宾果表",
+    "@newCardTitle": {
+        "description": "AppBar title of the new-card screen"
+    },
+    "editCardTitle": "编辑宾果表",
+    "@editCardTitle": {
+        "description": "AppBar title of the edit-card screen"
+    },
+    "cardNameLabel": "宾果表名称 *",
+    "@cardNameLabel": {
+        "description": "Label of the card-name text field"
+    },
+    "cardNameHint": "输入宾果表名称",
+    "@cardNameHint": {
+        "description": "Placeholder hint for the card-name text field"
+    },
+    "createCardButton": "创建宾果表",
+    "@createCardButton": {
+        "description": "Confirm button on the new-card screen"
+    },
+    "updateCardButton": "更新宾果表",
+    "@updateCardButton": {
+        "description": "Confirm button on the edit-card screen"
+    },
+    "newBoardPreMadeSectionTitle": "Your pre-made items",
+    "@newBoardPreMadeSectionTitle": {
+        "description": "Expandable section title for pre-made items on the new-board screen"
+    },
+    "newBoardPreMadeButton": "Start with pre-made items",
+    "@newBoardPreMadeButton": {
+        "description": "Button that opens pre-made item selection from the new-board screen"
+    },
+    "newBoardPreMadeChangeButton": "Change pre-made items",
+    "@newBoardPreMadeChangeButton": {
+        "description": "Button that reopens pre-made item selection after items have been applied"
+    },
+    "newBoardPreMadeClearButton": "Clear pre-made items",
+    "@newBoardPreMadeClearButton": {
+        "description": "Button that clears applied pre-made entries from the new-board form"
+    },
+    "newBoardPreMadeAppliedCount": "{count} pre-made entries applied",
+    "@newBoardPreMadeAppliedCount": {
+        "description": "Summary of how many pre-made entries are applied to the new-board form",
+        "placeholders": {
+            "count": {
+                "type": "int",
+                "example": "40"
+            }
+        }
+    },
+    "newBoardPreMadeFullSummary": "{used} will be drawn at random for this board.",
+    "@newBoardPreMadeFullSummary": {
+        "description": "Summary when applied pre-made entries can fill the new board",
+        "placeholders": {
+            "used": {
+                "type": "int",
+                "example": "25"
+            }
+        }
+    },
+    "newBoardPreMadePartialSummary": "{used} cells will be filled. {blank} will stay blank.",
+    "@newBoardPreMadePartialSummary": {
+        "description": "Summary when applied pre-made entries are fewer than the board cells",
+        "placeholders": {
+            "used": {
+                "type": "int",
+                "example": "10"
+            },
+            "blank": {
+                "type": "int",
+                "example": "15"
+            }
+        }
+    },
+    "defaultCardName": "宾果卡",
+    "@defaultCardName": {
+        "description": "Fallback title shown when a card has no name"
+    },
+    "toggleHint": "长按可勾选格子",
+    "@toggleHint": {
+        "description": "Hint banner above the bingo grid"
+    },
+    "editingHintBefore": "Press the lock icon",
+    "@editingHintBefore": {
+        "description": "First half of the hint that explains the lock toggle. The lock icon is rendered between the two halves."
+    },
+    "editingHintAfter": " to make the fields not editable anymore.",
+    "@editingHintAfter": {
+        "description": "Second half of the lock-toggle hint, rendered after the lock icon."
+    },
+    "deleteCardTitle": "Delete Card",
+    "@deleteCardTitle": {
+        "description": "Title of the delete-card confirmation dialog"
+    },
+    "deleteCardConfirm": "Are you sure you want to delete this card?",
+    "@deleteCardConfirm": {
+        "description": "Body of the delete-card confirmation dialog"
+    },
+    "cancel": "取消",
+    "@cancel": {
+        "description": "Generic cancel button"
+    },
+    "delete": "删除",
+    "@delete": {
+        "description": "Generic delete button"
+    },
+    "shuffleCardTitle": "Shuffle Card",
+    "@shuffleCardTitle": {
+        "description": "Title of the shuffle confirmation dialog"
+    },
+    "shuffleCardConfirm": "Are you sure you want to shuffle this card? All fields will be unchecked, after shuffling.",
+    "@shuffleCardConfirm": {
+        "description": "Body of the shuffle confirmation dialog"
+    },
+    "shuffle": "随机排列",
+    "@shuffle": {
+        "description": "Confirm button to shuffle the card"
+    },
+    "ratingPromptTitle": "Do you like Custom Bingo?",
+    "@ratingPromptTitle": {
+        "description": "Title of the dialog shown before asking for an app store review"
+    },
+    "ratingPromptBody": "If so, a quick store review helps others find it.",
+    "@ratingPromptBody": {
+        "description": "Body of the dialog shown before asking for an app store review"
+    },
+    "ratingPromptNo": "Not really",
+    "@ratingPromptNo": {
+        "description": "Dismiss button for the rating prompt dialog"
+    },
+    "ratingPromptYes": "Yes, I like it",
+    "@ratingPromptYes": {
+        "description": "Confirm button that continues to the native app store review flow"
+    },
+    "boardActionShare": "分享",
+    "@boardActionShare": {
+        "description": "Menu item that opens the share dialog from the board action bar"
+    },
+    "boardActionEditBoard": "编辑棋盘",
+    "@boardActionEditBoard": {
+        "description": "Menu item that opens the board edit flow from the board action bar"
+    },
+    "boardActionAddPreMadeItems": "Add pre-made items",
+    "@boardActionAddPreMadeItems": {
+        "description": "Debug menu item placeholder for filling a board with pre-made items"
+    },
+    "cellHint": "输入文字…",
+    "@cellHint": {
+        "description": "Placeholder for an empty bingo cell"
+    },
+    "edit": "编辑",
+    "@edit": {
+        "description": "Edit menu item in a cell's context menu"
+    },
+    "markDone": "Mark Done",
+    "@markDone": {
+        "description": "Cell context menu item: mark this cell as done"
+    },
+    "markNotDone": "Mark Not Done",
+    "@markNotDone": {
+        "description": "Cell context menu item: clear the done state"
+    },
+    "newCardMenuItem": "新建宾果棋盘",
+    "@newCardMenuItem": {
+        "description": "Menu item that opens the new-card screen"
+    },
+    "yourCardsHeader": "你的棋盘",
+    "@yourCardsHeader": {
+        "description": "Section header in the popup menu listing saved cards"
+    },
+    "settingsHeader": "设置",
+    "@settingsHeader": {
+        "description": "Section header in the popup menu"
+    },
+    "appearanceMenuItem": "Appearance",
+    "@appearanceMenuItem": {
+        "description": "Menu item that opens the appearance settings screen"
+    },
+    "settingsAppearanceSection": "外观",
+    "@settingsAppearanceSection": {
+        "description": "Section title for appearance settings"
+    },
+    "settingsPreferencesSection": "偏好设置",
+    "@settingsPreferencesSection": {
+        "description": "Section title for general preference settings"
+    },
+    "settingsBoardsSection": "棋盘",
+    "@settingsBoardsSection": {
+        "description": "Section title for board-related settings"
+    },
+    "settingsHelpSection": "更多",
+    "@settingsHelpSection": {
+        "description": "Section title for additional settings, help, and support entries"
+    },
+    "settingsSupportSection": "支持",
+    "@settingsSupportSection": {
+        "description": "Section title for supporting the developer"
+    },
+    "themeColorLabel": "主题颜色",
+    "@themeColorLabel": {
+        "description": "Label above the theme color selector in settings"
+    },
+    "themeColorSettingsDescription": "选择整个应用使用的配色。",
+    "@themeColorSettingsDescription": {
+        "description": "Settings helper text for the theme color selector"
+    },
+    "languageSettingsTitle": "语言",
+    "@languageSettingsTitle": {
+        "description": "Settings tile title for choosing the app language"
+    },
+    "languageSettingsSelectorLabel": "应用语言",
+    "@languageSettingsSelectorLabel": {
+        "description": "Label above the language dropdown in settings"
+    },
+    "languageSettingsSystemOption": "系统默认（{language}）",
+    "@languageSettingsSystemOption": {
+        "description": "Dropdown option that makes the app follow the phone/system language. The placeholder is the current phone language display name.",
+        "placeholders": {
+            "language": {
+                "type": "String",
+                "example": "Deutsch"
+            }
+        }
+    },
+    "languageSettingsSystemDescription": "跟随手机语言：{language}。",
+    "@languageSettingsSystemDescription": {
+        "description": "Settings helper text when no manual app language override is selected. The placeholder is the current phone language display name.",
+        "placeholders": {
+            "language": {
+                "type": "String",
+                "example": "Deutsch"
+            }
+        }
+    },
+    "languageSettingsOverrideDescription": "使用此语言，而不是手机语言。",
+    "@languageSettingsOverrideDescription": {
+        "description": "Settings helper text when a manual app language override is selected"
+    },
+    "darkModeLabel": "深色模式",
+    "@darkModeLabel": {
+        "description": "Label for the dark mode switch in settings"
+    },
+    "darkModeSettingsDescription": "使用更深色的界面。",
+    "@darkModeSettingsDescription": {
+        "description": "Settings helper text for the dark mode switch"
+    },
+    "enableConfettiLabel": "彩纸",
+    "@enableConfettiLabel": {
+        "description": "Label for the confetti preference switch"
+    },
+    "enableConfettiSettingsDescription": "完成宾果时显示庆祝效果。",
+    "@enableConfettiSettingsDescription": {
+        "description": "Settings helper text for the confetti preference switch"
+    },
+    "preMadeTilesTitle": "Pre-made tiles",
+    "@preMadeTilesTitle": {
+        "description": "Title of the pre-made tiles settings screen and menu entry"
+    },
+    "preMadeTilesSettingsDescription": "Create reusable tile text for future boards.",
+    "@preMadeTilesSettingsDescription": {
+        "description": "Settings entry helper text for pre-made tiles"
+    },
+    "preMadeTilesDescription": "Create reusable bingo entries here. When you create a new board, you can add them without typing everything again.",
+    "@preMadeTilesDescription": {
+        "description": "Description shown below the pre-made tiles screen title"
+    },
+    "preMadeTilesSelectMode": "Select",
+    "@preMadeTilesSelectMode": {
+        "description": "Segmented control label for selecting pre-made tiles"
+    },
+    "preMadeTilesEditMode": "Edit",
+    "@preMadeTilesEditMode": {
+        "description": "Segmented control label for editing pre-made tiles"
+    },
+    "preMadeTileHint": "Tile text",
+    "@preMadeTileHint": {
+        "description": "Placeholder for a pre-made tile text field"
+    },
+    "preMadeTilesAdd": "Add tile",
+    "@preMadeTilesAdd": {
+        "description": "Accessible label and tooltip for adding a pre-made tile"
+    },
+    "preMadeTilesDelete": "Delete tile",
+    "@preMadeTilesDelete": {
+        "description": "Accessible label and tooltip for deleting a pre-made tile"
+    },
+    "preMadeTilesSelectAll": "Un/select all",
+    "@preMadeTilesSelectAll": {
+        "description": "Checkbox label for toggling all pre-made tile selections"
+    },
+    "preMadeTilesSelectNone": "Select none",
+    "@preMadeTilesSelectNone": {
+        "description": "Button label for clearing all selected pre-made tiles"
+    },
+    "preMadeTilesApply": "Apply",
+    "@preMadeTilesApply": {
+        "description": "Button label for applying selected pre-made tiles to a board"
+    },
+    "preMadeTilesReplaceItems": "Replace items",
+    "@preMadeTilesReplaceItems": {
+        "description": "Button label for replacing current board items with selected pre-made items"
+    },
+    "preMadeTilesFillItems": "Fill items",
+    "@preMadeTilesFillItems": {
+        "description": "Button label for filling empty board items with selected pre-made items"
+    },
+    "preMadeTilesBoardActionHelp": "Replace swaps the board entries with a random draw from your selection. Fill only adds items to empty tiles. On odd boards, the center tile stays in place.",
+    "@preMadeTilesBoardActionHelp": {
+        "description": "Helper text explaining replace and fill actions for pre-made items on an existing board"
+    },
+    "preMadeTilesSelectedCount": "{selected} / {total} selected",
+    "@preMadeTilesSelectedCount": {
+        "description": "Count of selected pre-made tiles",
+        "placeholders": {
+            "selected": {
+                "type": "int",
+                "example": "12"
+            },
+            "total": {
+                "type": "int",
+                "example": "24"
+            }
+        }
+    },
+    "preMadeTilesEmptyTitle": "No tiles yet",
+    "@preMadeTilesEmptyTitle": {
+        "description": "Empty-state title for the pre-made tiles screen"
+    },
+    "preMadeTilesEmptyBody": "Add a tile to start building a reusable list.",
+    "@preMadeTilesEmptyBody": {
+        "description": "Empty-state helper text for the pre-made tiles screen"
+    },
+    "proposeFeatures": "Propose Features",
+    "@proposeFeatures": {
+        "description": "Menu item that opens the UserOrient feedback board"
+    },
+    "proposeFeaturesSettingsDescription": "Vote on ideas and suggest what to build next.",
+    "@proposeFeaturesSettingsDescription": {
+        "description": "Settings helper text for the feature request entry"
+    },
+    "supportMeDirectly": "Support the developer",
+    "@supportMeDirectly": {
+        "description": "Menu item that opens the direct-support paywall"
+    },
+    "supportMeDirectlySettingsDescription": "Help fund development and keep the app improving.",
+    "@supportMeDirectlySettingsDescription": {
+        "description": "Settings helper text for the direct support entry"
+    },
+    "supportCarouselProTitle": "Support Custom Bingo",
+    "@supportCarouselProTitle": {
+        "description": "Title of the home-screen support carousel item that opens the paywall"
+    },
+    "supportCarouselProSubtitle": "Unlock bonus colors and help keep the app independent.",
+    "@supportCarouselProSubtitle": {
+        "description": "Subtitle of the home-screen support carousel item that opens the paywall"
+    },
+    "supportCarouselRateTitle": "Enjoying the app?",
+    "@supportCarouselRateTitle": {
+        "description": "Title of the home-screen support carousel item that asks for a store review"
+    },
+    "supportCarouselRateSubtitle": "A quick review helps more people find Custom Bingo.",
+    "@supportCarouselRateSubtitle": {
+        "description": "Subtitle of the home-screen support carousel item that asks for a store review"
+    },
+    "rateTheApp": "Rate the app",
+    "@rateTheApp": {
+        "description": "Settings entry that opens the native store rating dialog"
+    },
+    "rateTheAppSettingsDescription": "Open the store rating prompt.",
+    "@rateTheAppSettingsDescription": {
+        "description": "Settings helper text for the app rating entry"
+    },
+    "contactMe": "Contact me",
+    "@contactMe": {
+        "description": "Settings entry that opens an email composer"
+    },
+    "contactMeSettingsDescription": "Send feedback, questions, or bug reports by email.",
+    "@contactMeSettingsDescription": {
+        "description": "Settings helper text for the contact email entry"
+    },
+    "paywallTitle": "Support Custom Bingo",
+    "@paywallTitle": {
+        "description": "AppBar title of the direct-support paywall"
+    },
+    "paywallThankYouTitle": "Thank you",
+    "@paywallThankYouTitle": {
+        "description": "Paywall title shown after Pro access is active"
+    },
+    "paywallSupportTitle": "Support Custom Bingo",
+    "@paywallSupportTitle": {
+        "description": "Main title on the direct-support paywall"
+    },
+    "paywallSupportBody": "This purchase supports me, the developer, directly. You get my gratitude and a few small bonus things for your boards.",
+    "@paywallSupportBody": {
+        "description": "Main body copy on the direct-support paywall"
+    },
+    "paywallBonusGratitude": "My gratitude, sincerely.",
+    "@paywallBonusGratitude": {
+        "description": "First benefit line on the direct-support paywall"
+    },
+    "paywallBonusColors": "A few extra board colors.",
+    "@paywallBonusColors": {
+        "description": "Second benefit line on the direct-support paywall"
+    },
+    "paywallBonusExtras": "Small supporter extras over time.",
+    "@paywallBonusExtras": {
+        "description": "Third benefit line on the direct-support paywall"
+    },
+    "paywallFreeForever": "No one ever needs to pay for this app. Custom Bingo stays usable for everyone.",
+    "@paywallFreeForever": {
+        "description": "Footer reassurance on the direct-support paywall"
+    },
+    "paywallLoadingPrice": "Loading price",
+    "@paywallLoadingPrice": {
+        "description": "Placeholder shown while the paywall price is loading"
+    },
+    "paywallUnavailable": "Unavailable",
+    "@paywallUnavailable": {
+        "description": "Paywall price/button text when purchases are unavailable"
+    },
+    "paywallSupportOnce": "Support once",
+    "@paywallSupportOnce": {
+        "description": "Purchase button label on the direct-support paywall"
+    },
+    "paywallRestorePurchase": "Restore purchase",
+    "@paywallRestorePurchase": {
+        "description": "Restore button label on the direct-support paywall"
+    },
+    "paywallProActiveToast": "Custom Bingo Pro is active.",
+    "@paywallProActiveToast": {
+        "description": "Toast shown after a successful Pro purchase"
+    },
+    "paywallPurchaseInactiveToast": "Purchase finished, but Pro is not active.",
+    "@paywallPurchaseInactiveToast": {
+        "description": "Toast shown if a purchase returns without Pro access"
+    },
+    "paywallProRestoredToast": "Custom Bingo Pro restored.",
+    "@paywallProRestoredToast": {
+        "description": "Toast shown after restoring Pro access"
+    },
+    "paywallNoPurchaseFoundToast": "No Pro purchase found.",
+    "@paywallNoPurchaseFoundToast": {
+        "description": "Toast shown when restore finds no Pro access"
+    },
+    "paywallPurchasesUnavailable": "Purchases are unavailable right now.",
+    "@paywallPurchasesUnavailable": {
+        "description": "Fallback error text for a paywall purchase error"
+    },
+    "paywallPlatformUnavailable": "Purchases are unavailable on this platform.",
+    "@paywallPlatformUnavailable": {
+        "description": "Fallback paywall text when purchases are not configured for the platform"
+    },
+    "paywallCouldNotLoad": "Could not load purchase information.",
+    "@paywallCouldNotLoad": {
+        "description": "Fallback paywall error text for an unknown purchase loading error"
+    },
+    "shareTitle": "分享宾果卡",
+    "@shareTitle": {
+        "description": "Title of the share dialog"
+    },
+    "shareDialogPrompt": "How would you like to share?",
+    "@shareDialogPrompt": {
+        "description": "Section header above the two share options"
+    },
+    "shareImageOptionTitle": "以图片分享",
+    "@shareImageOptionTitle": {
+        "description": "Title of the image-share option in the share dialog"
+    },
+    "shareImageOptionHelper": "Send a picture of your card. Anyone can see it — even without the app.",
+    "@shareImageOptionHelper": {
+        "description": "Helper text explaining what 'Share as image' does"
+    },
+    "shareImageOptionButton": "分享图片",
+    "@shareImageOptionButton": {
+        "description": "Confirm button on the image-share option"
+    },
+    "shareInviteOptionTitle": "邀请朋友一起玩",
+    "@shareInviteOptionTitle": {
+        "description": "Title of the play-together invite option"
+    },
+    "shareInviteOptionHelper": "Send this link to your friends who also have this app installed. They get the same card and you can play together.",
+    "@shareInviteOptionHelper": {
+        "description": "Helper text explaining what the invite link does"
+    },
+    "shareInviteIncludeMarks": "Include my checkmarks",
+    "@shareInviteIncludeMarks": {
+        "description": "Toggle label: include the sender's marks in the invite"
+    },
+    "shareInviteIncludeMarksHelper": "When on, your friends will see what you've already crossed off.",
+    "@shareInviteIncludeMarksHelper": {
+        "description": "Helper text under the include-checkmarks toggle"
+    },
+    "shareInviteOptionButton": "发送邀请",
+    "@shareInviteOptionButton": {
+        "description": "Confirm button on the invite-link option"
+    },
+    "shareInviteText": "和我一起玩“{name}”！在应用中打开：\n{link}",
+    "@shareInviteText": {
+        "description": "Body text passed to the system share sheet alongside the invite link",
+        "placeholders": {
+            "name": {
+                "type": "String",
+                "example": "Dateline BINGO"
+            },
+            "link": {
+                "type": "String",
+                "example": "https://bingogrid.web.app/import?d=…"
+            }
+        }
+    },
+    "close": "关闭",
+    "@close": {
+        "description": "Generic close button"
+    },
+    "shareSubject": "Bingo Card",
+    "@shareSubject": {
+        "description": "Subject/title used by the system share sheet"
+    },
+    "importTitle": "A friend shared a bingo card with you",
+    "@importTitle": {
+        "description": "Title of the import-card screen shown to the receiver"
+    },
+    "importBody": "Add it to your cards so you can play along?",
+    "@importBody": {
+        "description": "Body of the import-card screen"
+    },
+    "importConfirm": "添加到我的卡片",
+    "@importConfirm": {
+        "description": "Confirm button on the import-card screen"
+    },
+    "importCancel": "暂不",
+    "@importCancel": {
+        "description": "Cancel button on the import-card screen"
+    },
+    "importCollisionToast": "You already had a card with this name, so I added it as \"{newName}\".",
+    "@importCollisionToast": {
+        "description": "Toast shown after silently renaming an imported card to avoid a collision",
+        "placeholders": {
+            "newName": {
+                "type": "String",
+                "example": "Dateline BINGO (2)"
+            }
+        }
+    },
+    "importBadLinkToast": "Sorry, this invite couldn't be opened. Ask your friend to send it again.",
+    "@importBadLinkToast": {
+        "description": "Toast shown when an invite link is malformed"
+    },
+    "importOutdatedAppToast": "Update the app to open this invite.",
+    "@importOutdatedAppToast": {
+        "description": "Toast shown when an invite payload uses a newer schema"
+    },
+    "toastInfo": "信息",
+    "@toastInfo": {
+        "description": "Title of an informational toast"
+    },
+    "toastSuccess": "成功",
+    "@toastSuccess": {
+        "description": "Title of a success toast"
+    },
+    "toastError": "错误",
+    "@toastError": {
+        "description": "Title of an error toast"
+    },
+    "lastChangeNever": "上次更改：从未",
+    "@lastChangeNever": {
+        "description": "Footer line shown when a card has never been edited"
+    },
+    "lastChange": "上次更改：{date} {time}",
+    "@lastChange": {
+        "description": "Footer line showing when the card was last edited",
+        "placeholders": {
+            "date": {
+                "type": "String",
+                "example": "5.5.2026"
+            },
+            "time": {
+                "type": "String",
+                "example": "14:30"
+            }
+        }
+    },
+    "screenshotCaptionPlaying": "Just a simple app to create bingo board.\n\nNo signup, no ads, fully free to use.",
+    "@screenshotCaptionPlaying": {
+        "description": "Promotional caption for the screenshot showing a played bingo board"
+    },
+    "screenshotCaptionCreate": "Literally just 2 screens to create a bingo grid.",
+    "@screenshotCaptionCreate": {
+        "description": "Promotional caption for the screenshot showing the new-board screen"
+    },
+    "screenshotCaptionLocked": "That's it.",
+    "@screenshotCaptionLocked": {
+        "description": "Promotional caption for the screenshot showing the locked board"
+    },
+    "screenshotBoardName": "David's Wedding",
+    "@screenshotBoardName": {
+        "description": "Sample bingo board name used in generated screenshots"
+    },
+    "screenshotTilePhoneDuringVows": "Phone during vows",
+    "@screenshotTilePhoneDuringVows": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileChampagneSpilled": "Champagne spilled",
+    "@screenshotTileChampagneSpilled": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileSpeechTears": "Speech tears",
+    "@screenshotTileSpeechTears": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileDramaticEntrance": "Dramatic entrance",
+    "@screenshotTileDramaticEntrance": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileKidsDanceFloor": "Kids take the dance floor",
+    "@screenshotTileKidsDanceFloor": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileGuestToast": "Guest gives a toast",
+    "@screenshotTileGuestToast": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileCrowdClapsEarly": "Crowd claps early",
+    "@screenshotTileCrowdClapsEarly": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileDjClassic": "DJ plays a classic",
+    "@screenshotTileDjClassic": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    },
+    "screenshotTileGroupPhotoChaos": "Group photo chaos",
+    "@screenshotTileGroupPhotoChaos": {
+        "description": "Sample bingo tile text used in generated screenshots"
+    }
+}

--- a/lib/l10n/arb/app_zh.arb
+++ b/lib/l10n/arb/app_zh.arb
@@ -24,23 +24,23 @@
     "@updateCardButton": {
         "description": "Confirm button on the edit-card screen"
     },
-    "newBoardPreMadeSectionTitle": "Your pre-made items",
+    "newBoardPreMadeSectionTitle": "你的预制项目",
     "@newBoardPreMadeSectionTitle": {
         "description": "Expandable section title for pre-made items on the new-board screen"
     },
-    "newBoardPreMadeButton": "Start with pre-made items",
+    "newBoardPreMadeButton": "从预制项目开始",
     "@newBoardPreMadeButton": {
         "description": "Button that opens pre-made item selection from the new-board screen"
     },
-    "newBoardPreMadeChangeButton": "Change pre-made items",
+    "newBoardPreMadeChangeButton": "更改预制项目",
     "@newBoardPreMadeChangeButton": {
         "description": "Button that reopens pre-made item selection after items have been applied"
     },
-    "newBoardPreMadeClearButton": "Clear pre-made items",
+    "newBoardPreMadeClearButton": "清除预制项目",
     "@newBoardPreMadeClearButton": {
         "description": "Button that clears applied pre-made entries from the new-board form"
     },
-    "newBoardPreMadeAppliedCount": "{count} pre-made entries applied",
+    "newBoardPreMadeAppliedCount": "已应用 {count} 个预制条目",
     "@newBoardPreMadeAppliedCount": {
         "description": "Summary of how many pre-made entries are applied to the new-board form",
         "placeholders": {
@@ -50,7 +50,7 @@
             }
         }
     },
-    "newBoardPreMadeFullSummary": "{used} will be drawn at random for this board.",
+    "newBoardPreMadeFullSummary": "将为此棋盘随机抽取 {used} 个。",
     "@newBoardPreMadeFullSummary": {
         "description": "Summary when applied pre-made entries can fill the new board",
         "placeholders": {
@@ -60,7 +60,7 @@
             }
         }
     },
-    "newBoardPreMadePartialSummary": "{used} cells will be filled. {blank} will stay blank.",
+    "newBoardPreMadePartialSummary": "将填充 {used} 个格子，{blank} 个保持空白。",
     "@newBoardPreMadePartialSummary": {
         "description": "Summary when applied pre-made entries are fewer than the board cells",
         "placeholders": {
@@ -82,19 +82,19 @@
     "@toggleHint": {
         "description": "Hint banner above the bingo grid"
     },
-    "editingHintBefore": "Press the lock icon",
+    "editingHintBefore": "按锁定图标",
     "@editingHintBefore": {
         "description": "First half of the hint that explains the lock toggle. The lock icon is rendered between the two halves."
     },
-    "editingHintAfter": " to make the fields not editable anymore.",
+    "editingHintAfter": "，让格子不再可编辑。",
     "@editingHintAfter": {
         "description": "Second half of the lock-toggle hint, rendered after the lock icon."
     },
-    "deleteCardTitle": "Delete Card",
+    "deleteCardTitle": "删除卡片",
     "@deleteCardTitle": {
         "description": "Title of the delete-card confirmation dialog"
     },
-    "deleteCardConfirm": "Are you sure you want to delete this card?",
+    "deleteCardConfirm": "确定要删除这张卡片吗？",
     "@deleteCardConfirm": {
         "description": "Body of the delete-card confirmation dialog"
     },
@@ -106,11 +106,11 @@
     "@delete": {
         "description": "Generic delete button"
     },
-    "shuffleCardTitle": "Shuffle Card",
+    "shuffleCardTitle": "打乱卡片",
     "@shuffleCardTitle": {
         "description": "Title of the shuffle confirmation dialog"
     },
-    "shuffleCardConfirm": "Are you sure you want to shuffle this card? All fields will be unchecked, after shuffling.",
+    "shuffleCardConfirm": "确定要打乱这张卡片吗？打乱后所有格子都会取消勾选。",
     "@shuffleCardConfirm": {
         "description": "Body of the shuffle confirmation dialog"
     },
@@ -118,19 +118,19 @@
     "@shuffle": {
         "description": "Confirm button to shuffle the card"
     },
-    "ratingPromptTitle": "Do you like Custom Bingo?",
+    "ratingPromptTitle": "你喜欢 Custom Bingo 吗？",
     "@ratingPromptTitle": {
         "description": "Title of the dialog shown before asking for an app store review"
     },
-    "ratingPromptBody": "If so, a quick store review helps others find it.",
+    "ratingPromptBody": "如果喜欢，商店里的简短评价能帮助更多人发现它。",
     "@ratingPromptBody": {
         "description": "Body of the dialog shown before asking for an app store review"
     },
-    "ratingPromptNo": "Not really",
+    "ratingPromptNo": "不太喜欢",
     "@ratingPromptNo": {
         "description": "Dismiss button for the rating prompt dialog"
     },
-    "ratingPromptYes": "Yes, I like it",
+    "ratingPromptYes": "是的，我喜欢",
     "@ratingPromptYes": {
         "description": "Confirm button that continues to the native app store review flow"
     },
@@ -142,7 +142,7 @@
     "@boardActionEditBoard": {
         "description": "Menu item that opens the board edit flow from the board action bar"
     },
-    "boardActionAddPreMadeItems": "Add pre-made items",
+    "boardActionAddPreMadeItems": "添加预制项目",
     "@boardActionAddPreMadeItems": {
         "description": "Debug menu item placeholder for filling a board with pre-made items"
     },
@@ -154,11 +154,11 @@
     "@edit": {
         "description": "Edit menu item in a cell's context menu"
     },
-    "markDone": "Mark Done",
+    "markDone": "标记完成",
     "@markDone": {
         "description": "Cell context menu item: mark this cell as done"
     },
-    "markNotDone": "Mark Not Done",
+    "markNotDone": "标记未完成",
     "@markNotDone": {
         "description": "Cell context menu item: clear the done state"
     },
@@ -166,15 +166,53 @@
     "@newCardMenuItem": {
         "description": "Menu item that opens the new-card screen"
     },
+    "allBoardsMenuItem": "所有棋盘",
+    "@allBoardsMenuItem": {
+        "description": "Menu item that opens the list of all saved boards"
+    },
     "yourCardsHeader": "你的棋盘",
     "@yourCardsHeader": {
         "description": "Section header in the popup menu listing saved cards"
+    },
+    "noBoardsYet": "还没有棋盘",
+    "@noBoardsYet": {
+        "description": "Empty-state title shown when there are no saved boards"
+    },
+    "pageNotFoundTitle": "找不到页面",
+    "@pageNotFoundTitle": {
+        "description": "Title shown on the fallback route when a page cannot be found"
+    },
+    "homeButton": "首页",
+    "@homeButton": {
+        "description": "Button that navigates back to the home screen"
+    },
+    "revenueCatUserIdLabel": "RevenueCat 用户 ID：{userId}",
+    "@revenueCatUserIdLabel": {
+        "description": "Debug settings label showing the RevenueCat user id",
+        "placeholders": {
+            "userId": {
+                "type": "String",
+                "example": "abc123"
+            }
+        }
+    },
+    "copyRevenueCatUserIdTooltip": "复制 RevenueCat 用户 ID",
+    "@copyRevenueCatUserIdTooltip": {
+        "description": "Tooltip for copying the RevenueCat user id from debug settings"
+    },
+    "revenueCatUserIdCopiedToast": "已复制 RevenueCat 用户 ID。",
+    "@revenueCatUserIdCopiedToast": {
+        "description": "Toast shown after copying the RevenueCat user id"
     },
     "settingsHeader": "设置",
     "@settingsHeader": {
         "description": "Section header in the popup menu"
     },
-    "appearanceMenuItem": "Appearance",
+    "clearSettingsMenuItem": "清除设置",
+    "@clearSettingsMenuItem": {
+        "description": "Debug menu item that clears saved settings"
+    },
+    "appearanceMenuItem": "外观",
     "@appearanceMenuItem": {
         "description": "Menu item that opens the appearance settings screen"
     },
@@ -254,63 +292,63 @@
     "@enableConfettiSettingsDescription": {
         "description": "Settings helper text for the confetti preference switch"
     },
-    "preMadeTilesTitle": "Pre-made tiles",
+    "preMadeTilesTitle": "预制格子",
     "@preMadeTilesTitle": {
         "description": "Title of the pre-made tiles settings screen and menu entry"
     },
-    "preMadeTilesSettingsDescription": "Create reusable tile text for future boards.",
+    "preMadeTilesSettingsDescription": "为未来的棋盘创建可复用的格子文字。",
     "@preMadeTilesSettingsDescription": {
         "description": "Settings entry helper text for pre-made tiles"
     },
-    "preMadeTilesDescription": "Create reusable bingo entries here. When you create a new board, you can add them without typing everything again.",
+    "preMadeTilesDescription": "在这里创建可复用的宾果条目。创建新棋盘时，无需重新输入即可添加。",
     "@preMadeTilesDescription": {
         "description": "Description shown below the pre-made tiles screen title"
     },
-    "preMadeTilesSelectMode": "Select",
+    "preMadeTilesSelectMode": "选择",
     "@preMadeTilesSelectMode": {
         "description": "Segmented control label for selecting pre-made tiles"
     },
-    "preMadeTilesEditMode": "Edit",
+    "preMadeTilesEditMode": "编辑",
     "@preMadeTilesEditMode": {
         "description": "Segmented control label for editing pre-made tiles"
     },
-    "preMadeTileHint": "Tile text",
+    "preMadeTileHint": "格子文字",
     "@preMadeTileHint": {
         "description": "Placeholder for a pre-made tile text field"
     },
-    "preMadeTilesAdd": "Add tile",
+    "preMadeTilesAdd": "添加格子",
     "@preMadeTilesAdd": {
         "description": "Accessible label and tooltip for adding a pre-made tile"
     },
-    "preMadeTilesDelete": "Delete tile",
+    "preMadeTilesDelete": "删除格子",
     "@preMadeTilesDelete": {
         "description": "Accessible label and tooltip for deleting a pre-made tile"
     },
-    "preMadeTilesSelectAll": "Un/select all",
+    "preMadeTilesSelectAll": "全选/取消全选",
     "@preMadeTilesSelectAll": {
         "description": "Checkbox label for toggling all pre-made tile selections"
     },
-    "preMadeTilesSelectNone": "Select none",
+    "preMadeTilesSelectNone": "全部不选",
     "@preMadeTilesSelectNone": {
         "description": "Button label for clearing all selected pre-made tiles"
     },
-    "preMadeTilesApply": "Apply",
+    "preMadeTilesApply": "应用",
     "@preMadeTilesApply": {
         "description": "Button label for applying selected pre-made tiles to a board"
     },
-    "preMadeTilesReplaceItems": "Replace items",
+    "preMadeTilesReplaceItems": "替换项目",
     "@preMadeTilesReplaceItems": {
         "description": "Button label for replacing current board items with selected pre-made items"
     },
-    "preMadeTilesFillItems": "Fill items",
+    "preMadeTilesFillItems": "填充项目",
     "@preMadeTilesFillItems": {
         "description": "Button label for filling empty board items with selected pre-made items"
     },
-    "preMadeTilesBoardActionHelp": "Replace swaps the board entries with a random draw from your selection. Fill only adds items to empty tiles. On odd boards, the center tile stays in place.",
+    "preMadeTilesBoardActionHelp": "替换会从你的选择中随机抽取并替换棋盘条目。填充只会把项目添加到空格子。奇数棋盘中，中心格保持不变。",
     "@preMadeTilesBoardActionHelp": {
         "description": "Helper text explaining replace and fill actions for pre-made items on an existing board"
     },
-    "preMadeTilesSelectedCount": "{selected} / {total} selected",
+    "preMadeTilesSelectedCount": "已选择 {selected} / {total}",
     "@preMadeTilesSelectedCount": {
         "description": "Count of selected pre-made tiles",
         "placeholders": {
@@ -324,135 +362,135 @@
             }
         }
     },
-    "preMadeTilesEmptyTitle": "No tiles yet",
+    "preMadeTilesEmptyTitle": "还没有格子",
     "@preMadeTilesEmptyTitle": {
         "description": "Empty-state title for the pre-made tiles screen"
     },
-    "preMadeTilesEmptyBody": "Add a tile to start building a reusable list.",
+    "preMadeTilesEmptyBody": "添加一个格子，开始建立可复用列表。",
     "@preMadeTilesEmptyBody": {
         "description": "Empty-state helper text for the pre-made tiles screen"
     },
-    "proposeFeatures": "Propose Features",
+    "proposeFeatures": "提议功能",
     "@proposeFeatures": {
         "description": "Menu item that opens the UserOrient feedback board"
     },
-    "proposeFeaturesSettingsDescription": "Vote on ideas and suggest what to build next.",
+    "proposeFeaturesSettingsDescription": "为想法投票，并建议下一步要构建什么。",
     "@proposeFeaturesSettingsDescription": {
         "description": "Settings helper text for the feature request entry"
     },
-    "supportMeDirectly": "Support the developer",
+    "supportMeDirectly": "支持开发者",
     "@supportMeDirectly": {
         "description": "Menu item that opens the direct-support paywall"
     },
-    "supportMeDirectlySettingsDescription": "Help fund development and keep the app improving.",
+    "supportMeDirectlySettingsDescription": "帮助资助开发，让应用持续改进。",
     "@supportMeDirectlySettingsDescription": {
         "description": "Settings helper text for the direct support entry"
     },
-    "supportCarouselProTitle": "Support Custom Bingo",
+    "supportCarouselProTitle": "支持 Custom Bingo",
     "@supportCarouselProTitle": {
         "description": "Title of the home-screen support carousel item that opens the paywall"
     },
-    "supportCarouselProSubtitle": "Unlock bonus colors and help keep the app independent.",
+    "supportCarouselProSubtitle": "解锁额外颜色，并帮助应用保持独立。",
     "@supportCarouselProSubtitle": {
         "description": "Subtitle of the home-screen support carousel item that opens the paywall"
     },
-    "supportCarouselRateTitle": "Enjoying the app?",
+    "supportCarouselRateTitle": "喜欢这个应用吗？",
     "@supportCarouselRateTitle": {
         "description": "Title of the home-screen support carousel item that asks for a store review"
     },
-    "supportCarouselRateSubtitle": "A quick review helps more people find Custom Bingo.",
+    "supportCarouselRateSubtitle": "简短评价能帮助更多人发现 Custom Bingo。",
     "@supportCarouselRateSubtitle": {
         "description": "Subtitle of the home-screen support carousel item that asks for a store review"
     },
-    "rateTheApp": "Rate the app",
+    "rateTheApp": "评价应用",
     "@rateTheApp": {
         "description": "Settings entry that opens the native store rating dialog"
     },
-    "rateTheAppSettingsDescription": "Open the store rating prompt.",
+    "rateTheAppSettingsDescription": "打开商店评分提示。",
     "@rateTheAppSettingsDescription": {
         "description": "Settings helper text for the app rating entry"
     },
-    "contactMe": "Contact me",
+    "contactMe": "联系我",
     "@contactMe": {
         "description": "Settings entry that opens an email composer"
     },
-    "contactMeSettingsDescription": "Send feedback, questions, or bug reports by email.",
+    "contactMeSettingsDescription": "通过电子邮件发送反馈、问题或错误报告。",
     "@contactMeSettingsDescription": {
         "description": "Settings helper text for the contact email entry"
     },
-    "paywallTitle": "Support Custom Bingo",
+    "paywallTitle": "支持 Custom Bingo",
     "@paywallTitle": {
         "description": "AppBar title of the direct-support paywall"
     },
-    "paywallThankYouTitle": "Thank you",
+    "paywallThankYouTitle": "谢谢",
     "@paywallThankYouTitle": {
         "description": "Paywall title shown after Pro access is active"
     },
-    "paywallSupportTitle": "Support Custom Bingo",
+    "paywallSupportTitle": "支持 Custom Bingo",
     "@paywallSupportTitle": {
         "description": "Main title on the direct-support paywall"
     },
-    "paywallSupportBody": "This purchase supports me, the developer, directly. You get my gratitude and a few small bonus things for your boards.",
+    "paywallSupportBody": "这笔购买会直接支持我，也就是开发者。你会得到我的感谢，以及一些用于棋盘的小奖励。",
     "@paywallSupportBody": {
         "description": "Main body copy on the direct-support paywall"
     },
-    "paywallBonusGratitude": "My gratitude, sincerely.",
+    "paywallBonusGratitude": "真诚感谢。",
     "@paywallBonusGratitude": {
         "description": "First benefit line on the direct-support paywall"
     },
-    "paywallBonusColors": "A few extra board colors.",
+    "paywallBonusColors": "一些额外棋盘颜色。",
     "@paywallBonusColors": {
         "description": "Second benefit line on the direct-support paywall"
     },
-    "paywallBonusExtras": "Small supporter extras over time.",
+    "paywallBonusExtras": "未来的小支持者奖励。",
     "@paywallBonusExtras": {
         "description": "Third benefit line on the direct-support paywall"
     },
-    "paywallFreeForever": "No one ever needs to pay for this app. Custom Bingo stays usable for everyone.",
+    "paywallFreeForever": "没有人必须为这个应用付费。Custom Bingo 会继续对所有人可用。",
     "@paywallFreeForever": {
         "description": "Footer reassurance on the direct-support paywall"
     },
-    "paywallLoadingPrice": "Loading price",
+    "paywallLoadingPrice": "正在加载价格",
     "@paywallLoadingPrice": {
         "description": "Placeholder shown while the paywall price is loading"
     },
-    "paywallUnavailable": "Unavailable",
+    "paywallUnavailable": "不可用",
     "@paywallUnavailable": {
         "description": "Paywall price/button text when purchases are unavailable"
     },
-    "paywallSupportOnce": "Support once",
+    "paywallSupportOnce": "支持一次",
     "@paywallSupportOnce": {
         "description": "Purchase button label on the direct-support paywall"
     },
-    "paywallRestorePurchase": "Restore purchase",
+    "paywallRestorePurchase": "恢复购买",
     "@paywallRestorePurchase": {
         "description": "Restore button label on the direct-support paywall"
     },
-    "paywallProActiveToast": "Custom Bingo Pro is active.",
+    "paywallProActiveToast": "Custom Bingo Pro 已启用。",
     "@paywallProActiveToast": {
         "description": "Toast shown after a successful Pro purchase"
     },
-    "paywallPurchaseInactiveToast": "Purchase finished, but Pro is not active.",
+    "paywallPurchaseInactiveToast": "购买已完成，但 Pro 未启用。",
     "@paywallPurchaseInactiveToast": {
         "description": "Toast shown if a purchase returns without Pro access"
     },
-    "paywallProRestoredToast": "Custom Bingo Pro restored.",
+    "paywallProRestoredToast": "Custom Bingo Pro 已恢复。",
     "@paywallProRestoredToast": {
         "description": "Toast shown after restoring Pro access"
     },
-    "paywallNoPurchaseFoundToast": "No Pro purchase found.",
+    "paywallNoPurchaseFoundToast": "未找到 Pro 购买记录。",
     "@paywallNoPurchaseFoundToast": {
         "description": "Toast shown when restore finds no Pro access"
     },
-    "paywallPurchasesUnavailable": "Purchases are unavailable right now.",
+    "paywallPurchasesUnavailable": "目前无法购买。",
     "@paywallPurchasesUnavailable": {
         "description": "Fallback error text for a paywall purchase error"
     },
-    "paywallPlatformUnavailable": "Purchases are unavailable on this platform.",
+    "paywallPlatformUnavailable": "此平台不支持购买。",
     "@paywallPlatformUnavailable": {
         "description": "Fallback paywall text when purchases are not configured for the platform"
     },
-    "paywallCouldNotLoad": "Could not load purchase information.",
+    "paywallCouldNotLoad": "无法加载购买信息。",
     "@paywallCouldNotLoad": {
         "description": "Fallback paywall error text for an unknown purchase loading error"
     },
@@ -460,7 +498,7 @@
     "@shareTitle": {
         "description": "Title of the share dialog"
     },
-    "shareDialogPrompt": "How would you like to share?",
+    "shareDialogPrompt": "你想如何分享？",
     "@shareDialogPrompt": {
         "description": "Section header above the two share options"
     },
@@ -468,7 +506,7 @@
     "@shareImageOptionTitle": {
         "description": "Title of the image-share option in the share dialog"
     },
-    "shareImageOptionHelper": "Send a picture of your card. Anyone can see it — even without the app.",
+    "shareImageOptionHelper": "发送你的卡片图片。即使没有应用，任何人也能查看。",
     "@shareImageOptionHelper": {
         "description": "Helper text explaining what 'Share as image' does"
     },
@@ -480,15 +518,15 @@
     "@shareInviteOptionTitle": {
         "description": "Title of the play-together invite option"
     },
-    "shareInviteOptionHelper": "Send this link to your friends who also have this app installed. They get the same card and you can play together.",
+    "shareInviteOptionHelper": "把这个链接发送给同样安装了此应用的朋友。他们会得到同一张卡片，你们可以一起玩。",
     "@shareInviteOptionHelper": {
         "description": "Helper text explaining what the invite link does"
     },
-    "shareInviteIncludeMarks": "Include my checkmarks",
+    "shareInviteIncludeMarks": "包含我的勾选",
     "@shareInviteIncludeMarks": {
         "description": "Toggle label: include the sender's marks in the invite"
     },
-    "shareInviteIncludeMarksHelper": "When on, your friends will see what you've already crossed off.",
+    "shareInviteIncludeMarksHelper": "开启后，朋友会看到你已经划掉的内容。",
     "@shareInviteIncludeMarksHelper": {
         "description": "Helper text under the include-checkmarks toggle"
     },
@@ -514,15 +552,15 @@
     "@close": {
         "description": "Generic close button"
     },
-    "shareSubject": "Bingo Card",
+    "shareSubject": "宾果卡片",
     "@shareSubject": {
         "description": "Subject/title used by the system share sheet"
     },
-    "importTitle": "A friend shared a bingo card with you",
+    "importTitle": "朋友与你分享了一张宾果卡片",
     "@importTitle": {
         "description": "Title of the import-card screen shown to the receiver"
     },
-    "importBody": "Add it to your cards so you can play along?",
+    "importBody": "要添加到你的卡片中一起玩吗？",
     "@importBody": {
         "description": "Body of the import-card screen"
     },
@@ -534,7 +572,7 @@
     "@importCancel": {
         "description": "Cancel button on the import-card screen"
     },
-    "importCollisionToast": "You already had a card with this name, so I added it as \"{newName}\".",
+    "importCollisionToast": "你已经有同名卡片，所以我将它添加为“{newName}”。",
     "@importCollisionToast": {
         "description": "Toast shown after silently renaming an imported card to avoid a collision",
         "placeholders": {
@@ -544,11 +582,11 @@
             }
         }
     },
-    "importBadLinkToast": "Sorry, this invite couldn't be opened. Ask your friend to send it again.",
+    "importBadLinkToast": "抱歉，无法打开此邀请。请让朋友重新发送。",
     "@importBadLinkToast": {
         "description": "Toast shown when an invite link is malformed"
     },
-    "importOutdatedAppToast": "Update the app to open this invite.",
+    "importOutdatedAppToast": "请更新应用以打开此邀请。",
     "@importOutdatedAppToast": {
         "description": "Toast shown when an invite payload uses a newer schema"
     },
@@ -582,55 +620,55 @@
             }
         }
     },
-    "screenshotCaptionPlaying": "Just a simple app to create bingo board.\n\nNo signup, no ads, fully free to use.",
+    "screenshotCaptionPlaying": "一个用于创建宾果棋盘的简单应用。\\n\\n无需注册、无广告、完全免费。",
     "@screenshotCaptionPlaying": {
         "description": "Promotional caption for the screenshot showing a played bingo board"
     },
-    "screenshotCaptionCreate": "Literally just 2 screens to create a bingo grid.",
+    "screenshotCaptionCreate": "只需两个屏幕即可创建宾果网格。",
     "@screenshotCaptionCreate": {
         "description": "Promotional caption for the screenshot showing the new-board screen"
     },
-    "screenshotCaptionLocked": "That's it.",
+    "screenshotCaptionLocked": "就这样。",
     "@screenshotCaptionLocked": {
         "description": "Promotional caption for the screenshot showing the locked board"
     },
-    "screenshotBoardName": "David's Wedding",
+    "screenshotBoardName": "David 的婚礼",
     "@screenshotBoardName": {
         "description": "Sample bingo board name used in generated screenshots"
     },
-    "screenshotTilePhoneDuringVows": "Phone during vows",
+    "screenshotTilePhoneDuringVows": "宣誓时手机响",
     "@screenshotTilePhoneDuringVows": {
         "description": "Sample bingo tile text used in generated screenshots"
     },
-    "screenshotTileChampagneSpilled": "Champagne spilled",
+    "screenshotTileChampagneSpilled": "香槟洒了",
     "@screenshotTileChampagneSpilled": {
         "description": "Sample bingo tile text used in generated screenshots"
     },
-    "screenshotTileSpeechTears": "Speech tears",
+    "screenshotTileSpeechTears": "致辞落泪",
     "@screenshotTileSpeechTears": {
         "description": "Sample bingo tile text used in generated screenshots"
     },
-    "screenshotTileDramaticEntrance": "Dramatic entrance",
+    "screenshotTileDramaticEntrance": "戏剧性入场",
     "@screenshotTileDramaticEntrance": {
         "description": "Sample bingo tile text used in generated screenshots"
     },
-    "screenshotTileKidsDanceFloor": "Kids take the dance floor",
+    "screenshotTileKidsDanceFloor": "孩子们冲上舞池",
     "@screenshotTileKidsDanceFloor": {
         "description": "Sample bingo tile text used in generated screenshots"
     },
-    "screenshotTileGuestToast": "Guest gives a toast",
+    "screenshotTileGuestToast": "宾客敬酒",
     "@screenshotTileGuestToast": {
         "description": "Sample bingo tile text used in generated screenshots"
     },
-    "screenshotTileCrowdClapsEarly": "Crowd claps early",
+    "screenshotTileCrowdClapsEarly": "人群提前鼓掌",
     "@screenshotTileCrowdClapsEarly": {
         "description": "Sample bingo tile text used in generated screenshots"
     },
-    "screenshotTileDjClassic": "DJ plays a classic",
+    "screenshotTileDjClassic": "DJ 播放经典曲目",
     "@screenshotTileDjClassic": {
         "description": "Sample bingo tile text used in generated screenshots"
     },
-    "screenshotTileGroupPhotoChaos": "Group photo chaos",
+    "screenshotTileGroupPhotoChaos": "合影现场混乱",
     "@screenshotTileGroupPhotoChaos": {
         "description": "Sample bingo tile text used in generated screenshots"
     }

--- a/tasks.md
+++ b/tasks.md
@@ -50,6 +50,7 @@
 | T-035 | [DONE] | 2026-06-17 | Add app-locale Codex skill and localize screenshot copy | Completed 2026-06-17. Added `.codex/skills/app-locales`, moved screenshot copy and sample tiles into app ARB/localizations, regenerated l10n, and reran English/German screenshots. |
 | T-036 | [DONE] | 2026-06-22 | Reuse app visual widgets in screenshot flow | Completed 2026-06-22. Extracted reusable app visual widgets for the new-card form, board static view, and board action bar; screenshot flow now composes those real app components and uses updated fully-free copy. |
 | T-037 | [DONE] | 2026-06-25 | Add Hermes-managed daily GitHub issue workflow | Added token-gated loop scripts, local workflow skill, daily cron wrapper, and Hermes project profile; verified with dry run and shell syntax checks. |
+| T-038 | [DONE] | 2026-06-28 | Add app localization selector and new locales | Added device-language tracking, settings override via global beacon, EN/DE/FR/ES/PT/ZH/JA/AR ARB/generated files, and locale persistence tests. Verified `dart analyze .`, targeted locale test, and `flutter gen-l10n`; full test/build are blocked locally by pre-existing Flutter 3.44/phosphor_flutter final-IconData incompatibility and missing `libsqlite3.so`. |
 
 ## Feature Concepts
 

--- a/test/features/settings/app_locale_settings_test.dart
+++ b/test/features/settings/app_locale_settings_test.dart
@@ -1,0 +1,41 @@
+import 'package:custom_bingo/common/services/shared_prefs.dart';
+import 'package:custom_bingo/features/settings/app_locale_settings.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  group('app locale settings', () {
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      sharedPrefsBeacon.value = await SharedPreferences.getInstance();
+      appLocaleOverrideBeacon.value = getSavedAppLocale();
+    });
+
+    test('defaults to following the phone language', () {
+      expect(getSavedAppLocale(), isNull);
+      expect(appLocaleOverrideBeacon.value, isNull);
+    });
+
+    test('persists a manual app language override', () async {
+      await setAppLocaleOverride(const Locale('fr'));
+
+      expect(appLocaleOverrideBeacon.value, const Locale('fr'));
+      expect(getSavedAppLocale(), const Locale('fr'));
+    });
+
+    test('clears override to return to phone language tracking', () async {
+      await setAppLocaleOverride(const Locale('ja'));
+      await setAppLocaleOverride(null);
+
+      expect(appLocaleOverrideBeacon.value, isNull);
+      expect(getSavedAppLocale(), isNull);
+    });
+
+    test('ignores unsupported saved language codes', () async {
+      await sharedPrefsBeacon.value.setString('app_locale', 'it');
+
+      expect(getSavedAppLocale(), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Adds a global app-language override beacon backed by SharedPreferences.
- Keeps the default behavior as phone/system language tracking, with platform locale changes reflected through `phoneLocaleBeacon`.
- Adds a language selector to Settings → Appearance.
- Adds generated Flutter localizations for English, German, French, Spanish, Portuguese, Chinese, Japanese, and Arabic.
- Adds contextual metadata for the new language selector strings and preserves ARB metadata in new locale files.
- Adds tests for locale override persistence/reset/unsupported saved codes.

## Context / translation note
The new language selector strings are translated contextually for every supported locale. The new locale files also include a first contextual pass for the core app shell/settings/share strings so the app can compile and route all supported languages through Flutter l10n. A native-speaker copy review is still recommended before store release, especially for less-used feature/paywall/screenshot strings.

## Verification
- [x] `/root/flutter-sdk/bin/flutter gen-l10n`
- [x] `python3 -m json.tool` for all ARB files
- [x] `PATH=/root/flutter-sdk/bin:$PATH dart analyze .`
- [x] `/root/flutter-sdk/bin/flutter test test/features/settings/app_locale_settings_test.dart`

## Local verification limits
Full `flutter test` is blocked in this VPS environment by:
- missing `libsqlite3.so` for the existing Drift pre-made tile controller test
- Flutter 3.44.3 treating `IconData` as final, which breaks existing `phosphor_flutter 2.1.0` compilation in screenshot/web builds

Those blockers appear environment/dependency-related rather than introduced by this PR; the targeted locale test and analyzer pass.
